### PR TITLE
testing case: merge on atomic update

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -451,6 +451,18 @@ function fastUpdate(s, n) {
       assert(s1and2.end());
       assert.deepEqual(result, [12, 2, 4, 44, 1, 12, 2]);
     });
+    it('emmits all events from atomic update', function () {
+      var result = [];
+      var a = stream(1);
+      var b = stream([a], function() { return a() * 2; });
+      var c = stream([a], function() { return a() + 4; });
+      var d = flyd.merge(b, c);
+      stream([d], function () {
+        result.push(d());
+      });
+      a(2);
+      assert.deepEqual(result, [2, 5, 4, 6]);
+    });
   });
   describe('ap', function() {
     it('applies functions in stream', function() {


### PR DESCRIPTION
```
AssertionError: [ 2, 6 ] deepEqual [ 2, 5, 4, 6 ]
```