### PR TITLE
Fix coverage reporting to coveralls.io.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
   - "0.10"
   - "iojs"
 after_success:
-  - ./node_modules/.bin/istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage 
+  - "npm run post-to-coveralls-io"

--- a/package.json
+++ b/package.json
@@ -7,17 +7,20 @@
     "example": "examples",
     "test": "test"
   },
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "bluebird": "^2.9.13",
+    "coveralls": "^2.11.2",
+    "istanbul": "^0.3.15",
     "lodash": "^3.3.1",
     "mocha": "^2.2.1",
+    "mocha-lcov-reporter": "0.0.2",
     "ramda": "^0.14.0",
     "transducers.js": "0.3.x"
   },
   "scripts": {
-    "test": "./node_modules/mocha/bin/mocha"
+    "test": "./node_modules/mocha/bin/mocha",
+    "post-to-coveralls-io": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Some packages were missing, therefore Travis wasn't able to generate the coverage data nor send it to coveralls.io.

I think this fixes it.