### PR TITLE
Add flyd-onAnimationFrame module to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ will be added to this list.
   * [flyd-every](https://github.com/paldepind/flyd-every) - Takes a number of milliseconds t and creates a stream of the current time updated every t.
   * [flyd-aftersilence](https://github.com/paldepind/flyd-aftersilence) – Buffers values from a source stream in an array and emits it after a specified duration of silence from the source stream.
   * [flyd-inlast](https://github.com/paldepind/flyd-inlast) - Creates a stream that emits a list of all values from the source stream that were emitted in a specified duration.
+  * [flyd-onAnimationFrame](https://github.com/ThomWright/flyd-onAnimationFrame) - Emits values from a source stream on successive animation frames.
 
 ## Misc
 


### PR DESCRIPTION
Hey, big fan of what you're doing with `Flyd`. I started trying to use RxJS a couple of days ago but the whole OO aspect of it didn't work for me. The functional approach feels much more natural for this type of thing.

Anyway, I made this module. Let me know what you think. I only started using `Flyd` a few days ago so it's possible I'm butchering it!

I have a few more modules that I'll add too if this one gets accepted.