### PR TITLE
who to follow: add whatwg-fetch to dependencies

### DIFF
--- a/examples/who-to-follow/package.json
+++ b/examples/who-to-follow/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "flyd": "^0.1.6"
+    "flyd": "^0.1.6",
+    "whatwg-fetch": "^0.9.0"
   }
 }


### PR DESCRIPTION
required but not listed in dependencies