### PR TITLE
Add ability to send multiple values to another stream from inside a stream

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -107,7 +107,11 @@ var flushing = false;
 
 function flushUpdate() {
   flushing = true;
-  while (toUpdate.length > 0) updateDeps(toUpdate.shift());
+  while (toUpdate.length > 0) {
+    var s = toUpdate.shift();
+    if (s.vals.length > 0) s.val = s.vals.shift();
+    updateDeps(s);
+  }
   flushing = false;
 }
 
@@ -132,8 +136,8 @@ function updateStreamValue(s, n) {
     if (toUpdate.length > 0) flushUpdate(); else flushing = false;
   } else if (inStream === s) {
     markListeners(s, s.listeners);
-  } else if (s.queued === false) {
-    s.queued = true;
+  } else {
+    s.vals.push(n);
     toUpdate.push(s);
   }
 }
@@ -165,6 +169,7 @@ function createStream() {
   }
   s.hasVal = false;
   s.val = undefined;
+  s.vals = [];
   s.listeners = [];
   s.queued = false;
   s.end = undefined;

--- a/test/index.js
+++ b/test/index.js
@@ -204,6 +204,22 @@ describe('stream', function() {
     n(4)(6)(2)(8)(3)(4);
     assert.deepEqual(result, [6, 8]);
   });
+  it('can set another stream\'s value multiple times from inside a stream', function() {
+    var result = [];
+    var a = stream();
+    var b = stream();
+    stream([b], function() {
+      a(b());
+      a();
+      a(b() + 1);
+      assert.equal(a(), 2);
+    });
+    stream([a], function(self) {
+      result.push(a());
+    });
+    b(1);
+    assert.deepEqual(result, [1, 2]);
+  });
   describe('ending a stream', function() {
     it('works for streams without dependencies', function() {
       var s = stream(1);
@@ -671,20 +687,6 @@ describe('stream', function() {
       });
       a(2);
       assert.deepEqual(result, [7, 10]);
-    });
-    it('only queues one update', function() {
-      var result = [];
-      var a = stream();
-      var b = stream();
-      stream([b], function() { 
-        a(b());
-        a(b() + 1);
-      });
-      stream([a], function(self) {
-        result.push(a());
-      });
-      b(1);
-      assert.deepEqual(result, [2]);
     });
     it('does not glitch', function() {
       var result = [];


### PR DESCRIPTION
This PR adds the ability to send multiple values to another stream from inside a stream while maintaining atomic updates, as discussed in #40. As a result, this no longer enqueues only one update.

This also fixes the `forwardTo` issue introduced in `0.1.13`.

