### PR TITLE
Add modules under /module

### DIFF
--- a/module/aftersilence/README.md
+++ b/module/aftersilence/README.md
@@ -1,0 +1,21 @@
+# flyd-aftersilence
+Buffers values from a source stream in an array and emits it after a
+specified duration of silence from the source stream.
+
+__Signature__
+
+`Stream a -> Stream b`
+
+__Example__
+
+```javascript
+afterSilence(function(values) {
+  console.log('You achieved a combo of + values.length + '!');
+}, afterSilence(1000, birdsShot);
+```
+
+```javascript
+afterSilence(function(values) {
+  console.log('You typed: "' + values.join('') + '" without any pauses');
+}, afterSilence(300, characterTyped);
+```

--- a/module/aftersilence/index.js
+++ b/module/aftersilence/index.js
@@ -1,0 +1,14 @@
+var flyd = require('flyd');
+
+module.exports = function(dur, s) {
+  var scheduled;
+  var buffer = [];
+  return flyd.stream([s], function(self) {
+    buffer.push(s());
+    clearTimeout(scheduled);
+    scheduled = setTimeout(function() {
+      self(buffer);
+      buffer = [];
+    }, dur);
+  });
+};

--- a/module/aftersilence/test/index.js
+++ b/module/aftersilence/test/index.js
@@ -1,0 +1,61 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+
+var afterSilence = require('../aftersilence.js');
+
+// KISS way of testing time dependent code :)
+
+describe('afterSilence', function() {
+  it('correctly buffers values', function(done) {
+    var result = [];
+    var i = 0;
+    var s1 = stream();
+    var push = function() {
+      s1(i++);
+    };
+    var s2 = afterSilence(50, s1);
+    flyd.map(function(vs) {
+      result.push(vs);
+    }, s2);
+    setTimeout(push, 20);
+    setTimeout(push, 30);
+    setTimeout(push, 40);
+    setTimeout(push, 95);
+    setTimeout(push, 100);
+    setTimeout(push, 110);
+    setTimeout(push, 120);
+    setTimeout(push, 175);
+    setTimeout(function() {
+      assert.deepEqual(result, [
+          [0, 1, 2],
+          [3, 4, 5, 6],
+          [7],
+      ]);
+      done();
+    }, 240);
+  });
+  it('only emits values after specified silence', function(done) {
+    var result = [];
+    var i = 0;
+    var s1 = stream();
+    var push = function() {
+      s1(i++);
+    };
+    var s2 = afterSilence(20, s1);
+    flyd.map(function(vs) {
+      result.push(vs);
+    }, s2);
+    setTimeout(push, 10);
+    setTimeout(push, 20);
+    setTimeout(push, 30);
+    setTimeout(push, 40);
+    setTimeout(function() {
+      assert.equal(result.length, 0);
+    }, 50);
+    setTimeout(function() {
+      assert.deepEqual(result, [[0, 1, 2, 3]]);
+      done();
+    }, 65);
+  });
+});

--- a/module/droprepeats/README.md
+++ b/module/droprepeats/README.md
@@ -1,0 +1,49 @@
+# flyd-droprepeats
+
+Drops consecutively repeated values from a
+[Flyd](https://github.com/paldepind/flyd) stream.
+
+## API
+
+### dropRepeats(s)
+
+Drops repeated values from stream `s`. Equality is determined by reference.
+
+__Signature__
+
+`Stream a -> Stream a`
+
+__Usage__
+
+```js
+var dropRepeats = require('flyd-droprepeats').dropRepeats;
+var append = function(arr, x) {
+  return arr.concat(x);
+};
+
+var s = flyd.stream();
+var noRepeats = dropRepeats(s);
+var collect = flyd.scan(append, [], noRepeats);
+s(1)(2)(2)(3);
+collect() // [1, 2, 3]
+```
+
+### dropRepeatsWith(fn, s)
+
+Drops repeated values from stream `s`, but also takes a function `fn` that
+will be used to determine equality.
+
+__Signature__
+
+`(a -> b -> Boolean) -> Stream a -> Stream a`
+
+```js
+var dropRepeatsWith = require('flyd-droprepeats').dropRepeatsWith;
+var s = flyd.stream();
+// Ramda's `equals` determines equality by value
+var noRepeats = dropRepeatsWith(R.equals, s);
+var collect = flyd.scan(append, [], noRepeats);
+s({ foo: 'bar' });
+s({ foo: 'bar' });
+collect() // [{ foo: 'bar' }]
+```

--- a/module/droprepeats/index.js
+++ b/module/droprepeats/index.js
@@ -1,0 +1,21 @@
+var flyd = require('flyd');
+
+function dropRepeatsWith(eq, s) {
+  var prev;
+  return flyd.stream([s], function(self) {
+    if (!eq(s.val, prev)) {
+      self(s.val);
+      prev = s.val;
+    }
+  });
+}
+
+exports.dropRepeats = function(s) {
+  return dropRepeatsWith(strictEq, s);
+};
+
+exports.dropRepeatsWith = flyd.curryN(2, dropRepeatsWith);
+
+function strictEq(a, b) {
+  return a === b;
+}

--- a/module/droprepeats/test/index.js
+++ b/module/droprepeats/test/index.js
@@ -1,0 +1,51 @@
+var flyd = require('flyd');
+var stream = flyd.stream;
+var dropRepeats = require('../').dropRepeats;
+var dropRepeatsWith = require('../').dropRepeatsWith;
+var R = require('ramda');
+var assert = require('chai').assert;
+
+var collect = flyd.scan(R.flip(R.append), []);
+
+describe('dropRepeats', function() {
+  it('drops consecutive repeated values', function() {
+    var s = stream();
+    var all = collect(dropRepeats(s));
+    s(1)(2)(2)(3);
+    assert.deepEqual(all(), [1, 2, 3]);
+  });
+
+  it('doesn\'t determine equality by value', function() {
+    var s = stream();
+    var all = collect(dropRepeats(s));
+    s({ foo: 'bar' });
+    s({ foo: 'bar' });
+    assert.deepEqual(all(), [
+      { foo: 'bar' },
+      { foo: 'bar' },
+    ]);
+  });
+});
+
+describe('dropRepeatsWith', function() {
+  it('takes a function for using custom equality logic', function() {
+    var s = stream();
+    var all = collect(dropRepeatsWith(R.equals, s));
+    s({ foo: 'bar' });
+    s({ foo: 'bar' });
+    assert.deepEqual(all(), [
+      { foo: 'bar' }
+    ]);
+  });
+
+  it('is curried', function() {
+    var s = stream();
+    var equalsDropper = dropRepeatsWith(R.equals);
+    var all = collect(equalsDropper(s));
+    s({ foo: 'bar' });
+    s({ foo: 'bar' });
+    assert.deepEqual(all(), [
+      { foo: 'bar' }
+    ]);
+  });
+});

--- a/module/every/README.md
+++ b/module/every/README.md
@@ -1,0 +1,16 @@
+# flyd-every
+Takes a number of milliseconds t and creates a stream of the current time updated every t.
+
+__Signature__
+
+`Number -> Stream Number`
+
+__Usage__
+
+```javascript
+var everySecond = every(1000);
+flyd.map(function(time) {
+  // I'm called once every second
+  console.log('Current time is, time);
+}, everySecond);
+```

--- a/module/every/index.js
+++ b/module/every/index.js
@@ -1,0 +1,15 @@
+var flyd = require('flyd');
+
+module.exports = function(dur) {
+  var s = flyd.stream();
+  var target = Date.now();
+  function timer() {
+    if (s.end()) return;
+    var now = Date.now();
+    target += dur;
+    s(now);
+    setTimeout(timer, target - now);
+  }
+  timer();
+  return s;
+};

--- a/module/every/test/browsertest/index.html
+++ b/module/every/test/browsertest/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <title>Every drift test</title>
+    <script type="text/javascript" src="build.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/module/every/test/browsertest/script.js
+++ b/module/every/test/browsertest/script.js
@@ -1,0 +1,12 @@
+var flyd = require('flyd');
+var every = require('../every.js');
+
+var dur = 1000;
+var startTime, ticks = 0;
+var e = every(dur);
+flyd.map(function(t) {
+  startTime === undefined ? startTime = t : ++ticks;
+  console.log(t);
+  console.log('Drift: ' + (startTime + (ticks * dur) - t));
+  //console.log(t);
+}, e);

--- a/module/every/test/index.js
+++ b/module/every/test/index.js
@@ -1,0 +1,34 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var every = require('../every.js');
+
+describe('every', function() {
+  var e;
+  afterEach(function() {
+    e.end(true);
+  });
+  it('invokes callback the correct amount of times', function(done) {
+    var times = 0;
+    e = every(50);
+    flyd.map(function() { ++times; }, e);
+    setTimeout(function() {
+      assert.equal(5, times);
+      done();
+    }, 225);
+  });
+  it('ends', function(done) {
+    var times = 0;
+    e = every(50);
+    var endVal;
+    flyd.map(function() { ++times; }, e);
+    setTimeout(function() {
+      assert.equal(5, times);
+      endVal = e();
+      e.end(true);
+      setTimeout(function() {
+        assert.equal(endVal, e());
+        done();
+      }, 225);
+    }, 225);
+  });
+});

--- a/module/filter/README.md
+++ b/module/filter/README.md
@@ -1,0 +1,14 @@
+# flyd-filter
+Filter function for Flyd.
+
+# Usage
+
+```javascript
+var numbers = flyd.stream();
+var largeNumbers = filter(over5, numbers);
+flyd.map(function(n) {
+  // called with 6, 7 and 10
+}, largeNumbers);
+numbers(2)(6)(5)(3)(7)(10)(5);
+
+```

--- a/module/filter/index.js
+++ b/module/filter/index.js
@@ -1,0 +1,7 @@
+var flyd = require('flyd');
+
+module.exports = function(fn, s) {
+  return flyd.stream([s], function(self) {
+    if (fn(s())) self(s.val);
+  });
+};

--- a/module/filter/test/index.js
+++ b/module/filter/test/index.js
@@ -1,0 +1,20 @@
+var assert = require('assert');
+var flyd = require('flyd');
+
+var filter = require('../filter.js');
+
+describe('filter', function() {
+  it('only lets values passing the filter through', function() {
+    function over5(n) {
+      return n > 5;
+    }
+    var result = [];
+    var numbers = flyd.stream();
+    var largeNumbers = filter(over5, numbers);
+    flyd.map(function(n) {
+      result.push(n);
+    }, largeNumbers);
+    numbers(2)(6)(5)(3)(7)(10)(5);
+    assert.deepEqual(result, [6, 7, 10]);
+  });
+});

--- a/module/flatmap/README.md
+++ b/module/flatmap/README.md
@@ -1,0 +1,6 @@
+# flyd-flatmap
+flatMap function for Flyd.
+
+# Usage
+```
+```

--- a/module/flatmap/index.js
+++ b/module/flatmap/index.js
@@ -1,0 +1,7 @@
+var flyd = require('flyd');
+
+module.exports = function(f, s) {
+  return flyd.stream([s], function(own) {
+    flyd.map(own, f(s()));
+  });
+};

--- a/module/flatmap/test/index.js
+++ b/module/flatmap/test/index.js
@@ -1,0 +1,38 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+var flatMap = require('../flatmap.js');
+
+describe('flatMap', function() {
+  it('applies function to values in stream', function() {
+    var result = [];
+    function f(v) {
+      result.push(v);
+      return stream();
+    }
+    var s = stream();
+    flatMap(f, s);
+    s(1)(2)(3)(4)(5);
+    assert.deepEqual(result, [1, 2, 3, 4, 5]);
+  });
+  it('returns stream with result from all streams created by function', function() {
+    var result = [];
+    function f(v) {
+      var s = stream();
+      setImmediate(function() {
+        s(v+1)(v+2)(v+3);
+      });
+      return s;
+    }
+    var s = stream();
+    flyd.map(function(v) {
+      result.push(v);
+    }, flatMap(f, s));
+    s(1)(3)(5);
+    setImmediate(function() {
+      assert.deepEqual(result, [2, 3, 4,
+                                4, 5, 6,
+                                6, 7, 8]);
+    });
+  });
+});

--- a/module/forwardto/README.md
+++ b/module/forwardto/README.md
@@ -1,0 +1,28 @@
+# flyd-forwardto
+Create a new stream that passes all values through a function and forwards them
+to a target stream.
+
+This function is inspired by the [Elm
+function](http://package.elm-lang.org/packages/elm-lang/core/2.0.1/Signal#forwardTo)
+of the same name.
+
+__Signature__
+
+`Stream b -> (a -> b) -> Stream a`
+
+__Example__
+
+```javascript
+// We create a stream of numbers
+var numbers = flyd.stream();
+// And another stream that squares the numbers
+var squaredNumbers = flyd.map(function(n) { return n*n; }, numbers);
+// Add a logger just for show
+flyd.map(function(n) { console.log(n); }, squaredNumbers);
+// For some reason we have a lot of string of numbers, but we can't
+// send them down the `numbers` stream. That would wreck havoc in the
+// squaring function. `forwardTo` to the resque!
+var stringNumbers = forwardTo(numbers, parseInt);
+stringNumbers('7'); // `49` is logged
+```
+

--- a/module/forwardto/index.js
+++ b/module/forwardto/index.js
@@ -1,0 +1,7 @@
+var flyd = require('flyd');
+
+module.exports = flyd.curryN(2, function(targ, fn) {
+  var s = flyd.stream();
+  flyd.map(function(v) { targ(fn(v)); }, s);
+  return s;
+});

--- a/module/forwardto/test/index.js
+++ b/module/forwardto/test/index.js
@@ -1,0 +1,16 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var forwardTo = require('../forwardto.js');
+
+describe('forwardTo', function() {
+  it('forwads values', function() {
+    var result = [];
+    var target = flyd.stream();
+    function fn1(v) { result.push(v); }
+    function fn2(v) { result.push(2*v); return v; }
+    flyd.map(fn1, target);
+    var fw = forwardTo(target, fn2);
+    fw(1)(2)(3);
+    assert.deepEqual(result, [2, 1, 4, 2, 6, 3]);
+  });
+});

--- a/module/inlast/README.md
+++ b/module/inlast/README.md
@@ -1,0 +1,2 @@
+# flyd-inlast
+Creates a stream with emits a list of all values from the source stream that where emitted in a specified duration.

--- a/module/inlast/index.js
+++ b/module/inlast/index.js
@@ -1,0 +1,11 @@
+var flyd = require('flyd');
+
+module.exports = flyd.curryN(2, function(dur, s) {
+  var values = [];
+  return flyd.stream([s], function(self) {
+    setTimeout(function() {
+      self(values = values.slice(1));
+    }, dur);
+    return (values = values.concat([s()]));
+  });
+});

--- a/module/inlast/test/index.js
+++ b/module/inlast/test/index.js
@@ -1,0 +1,73 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+
+var inLast = require('../inlast.js');
+
+describe('inLast', function() {
+  it('adds values', function(done) {
+    var s = stream();
+    var lastMs = inLast(50, s);
+    s(1);
+    setTimeout(function() {
+      assert.deepEqual(lastMs(), [1]);
+      s(2);
+    }, 20);
+    setTimeout(function() {
+      assert.deepEqual(lastMs(), [1, 2]);
+      done();
+    }, 40);
+  });
+  it('adds and removes values', function(done) {
+    var s = stream();
+    var lastMs = inLast(50, s);
+    s(1);
+    setTimeout(function() {
+      assert.deepEqual(lastMs(), [1]);
+      s(2);
+    }, 35);
+    setTimeout(function() {
+      assert.deepEqual(lastMs(), [1, 2]);
+      s(3);
+    }, 40);
+    setTimeout(function() {
+      assert.deepEqual(lastMs(), [2, 3]);
+      s(4);
+    }, 60);
+    setTimeout(function() {
+      assert.deepEqual(lastMs(), [2, 3, 4]);
+      s(5);
+    }, 80);
+    setTimeout(function() {
+      assert.deepEqual(lastMs(), [4, 5]);
+      done();
+    }, 100);
+  });
+  it('is updated when values come and go', function(done) {
+    var result = [];
+    var s = stream();
+    var lastMs = inLast(50, s);
+    flyd.map(function(a) { result.push(a); }, lastMs);
+    s(1);
+    setTimeout(function() { s(2); }, 35);
+    setTimeout(function() { s(3); }, 40);
+    // 1 leaves
+    setTimeout(function() { s(4); }, 60);
+    setTimeout(function() { s(5); }, 80);
+    // 2 leaves
+    // 3 leaves
+    setTimeout(function() {
+      assert.deepEqual(result, [
+        [1],
+        [1, 2],
+        [1, 2, 3],
+        [2, 3],
+        [2, 3, 4],
+        [2, 3, 4, 5],
+        [3, 4, 5],
+        [4, 5],
+      ]);
+      done();
+    }, 100);
+  });
+});

--- a/module/keepwhen/README.md
+++ b/module/keepwhen/README.md
@@ -1,0 +1,13 @@
+# flyd-keepwhen
+keepWhen function for Flyd.
+
+Keeps values from the second stream when the first stream is true (true as in
+`=== true`).
+
+# Usage
+```
+var closeDropdown = keepWhen(popupOpen, backgroundClicked);
+flyd.map(closeDropdown, function() {
+  // Do stuff.
+});
+```

--- a/module/keepwhen/index.js
+++ b/module/keepwhen/index.js
@@ -1,0 +1,8 @@
+var flyd = require('flyd');
+
+// Stream bool -> Stream a -> Stream a
+module.exports = flyd.curryN(2, function(sBool, sA) {
+  return flyd.stream([sA], function(self) {
+    if (sBool() !== false) self(sA());
+  });
+});

--- a/module/keepwhen/test/index.js
+++ b/module/keepwhen/test/index.js
@@ -1,0 +1,37 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+
+var keepWhen = require('../keepwhen.js');
+
+describe('keepWhen', function() {
+  it('keeps values from second stream when first is true', function() {
+    var result = [];
+    var s = stream(1);
+    var b = stream(false);
+    var k = keepWhen(b, s);
+    flyd.map(function(v) {
+      result.push(v);
+    }, k);
+    s(2);
+    b(true);
+    s(3)(4);
+    b(false);
+    s(5);
+    b(true);
+    s(6);
+    assert.deepEqual(result, [3, 4, 6]);
+  });
+  it('doesnt emit anything until second stream has a value', function() {
+    var result = [];
+    var s = stream();
+    var b = stream(false);
+    var k = keepWhen(b, s);
+    flyd.map(function(v) {
+      result.push(v);
+    }, k);
+    b(true)(false)(true);
+    s(3)(4);
+    assert.deepEqual(result, [3, 4]);
+  });
+});

--- a/module/lift/README.md
+++ b/module/lift/README.md
@@ -1,0 +1,18 @@
+# flyd-lift
+Lift function for [Flyd](https://github.com/paldepind/flyd).
+
+# Usage
+
+```javascript
+var addThree = function(a, b, c) {
+  return a + b + c;
+};
+
+var n1 = stream(1),
+    n2 = stream(4),
+    n3 = stream(9);
+
+var sum = lift(addThree, n1, n2, n3);
+
+sum(); // 14
+```

--- a/module/lift/index.js
+++ b/module/lift/index.js
@@ -1,0 +1,10 @@
+var flyd = require('flyd');
+
+module.exports = function(f /* , streams */) {
+  var streams = Array.prototype.slice.call(arguments, 1);
+  var vals = [];
+  return flyd.stream(streams, function() {
+    for (var i = 0; i < streams.length; ++i) vals[i] = streams[i]();
+    return f.apply(null, vals);
+  });
+};

--- a/module/lift/test/index.js
+++ b/module/lift/test/index.js
@@ -1,0 +1,32 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+var lift = require('../flyd-lift.js');
+
+describe('lift', function() {
+  it('applies a function to two streams', function() {
+    var add = function(x, y) { return x + y; };
+    var x = stream(3);
+    var y = stream(4);
+    var sum = lift(add, x, y);
+    assert.equal(sum(), x() + y());
+    x(12);
+    assert.equal(sum(), x() + y());
+    y(3);
+    assert.equal(sum(), x() + y());
+  });
+  it('applies a function to five streams', function() {
+    var add = function(a, b, c, d, e) { return a + b + c + d + e; };
+    var a = stream(1);
+    var b = stream(2);
+    var c = stream(3);
+    var d = stream(4);
+    var e = stream(5);
+    var sum = lift(add, a, b, c, d, e);
+    assert.equal(sum(), a() + b() + c() + d() + e());
+    e(12); d(2); b(0);
+    assert.equal(sum(), a() + b() + c() + d() + e());
+    a(3); c(3);
+    assert.equal(sum(), a() + b() + c() + d() + e());
+  });
+});

--- a/module/obj/README.md
+++ b/module/obj/README.md
@@ -1,0 +1,2 @@
+# flyd-obj
+Functions for working with Flyd stream in objects.

--- a/module/obj/index.js
+++ b/module/obj/index.js
@@ -1,0 +1,44 @@
+var flyd = require('flyd');
+
+function isPlainObject(obj) {
+  return obj !== null && typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype;
+}
+
+var streamProps = function(from) {
+  var to = {};
+  for (var key in from) {
+    if (from.hasOwnProperty(key)) {
+      to[key] = isPlainObject(from[key]) ? streamProps(from[key]) : flyd.stream(from[key]);
+    }
+  }
+  return to;
+};
+
+var extractProps = function(obj) {
+  var newObj = {};
+  for (var key in obj) {
+    if (obj.hasOwnProperty(key)) {
+      newObj[key] = isPlainObject(obj[key]) ? extractProps(obj[key])
+                  : flyd.isStream(obj[key]) ? obj[key]()
+                                            : obj[key];
+    }
+  }
+  return newObj;
+};
+
+var stream = function(obj) {
+  var streams = Object.keys(obj).map(function(key) {
+    return isPlainObject(obj[key]) ? stream(obj[key])
+         : flyd.isStream(obj[key]) ? obj[key]
+                                   : flyd.stream(obj[key]);
+  });
+  return flyd.stream(streams, function() {
+    return extractProps(obj);
+  });
+};
+
+module.exports = {
+  streamProps: streamProps,
+  extractProps: extractProps,
+  stream: stream
+};

--- a/module/obj/test/index.js
+++ b/module/obj/test/index.js
@@ -1,0 +1,95 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+
+var obj = require('../obj.js');
+
+describe('stream props', function() {
+  it('converts the properties in an object to streams', function() {
+    var o = {one: 1, two: 2, three: 3};
+    var oS = obj.streamProps(o);
+    assert.equal(o.one, oS.one());
+    assert.equal(o.two, oS.two());
+    assert.equal(o.three, oS.three());
+  });
+  it('handles converting nested properties to nested streams', function(){
+    var o = {nested: {value: 'val', deeper: {deepVal: 'deepVal'}}};
+    var oS = obj.streamProps(o);
+    assert.equal(o.nested.value, oS.nested.value());
+    assert.equal(o.nested.deeper.deepVal, oS.nested.deeper.deepVal());
+  });
+});
+
+describe('stream object', function() {
+  var o = {one: 1, two: 2, three: 3};
+  it('returns a stream', function() {
+    var oS = obj.stream(obj.streamProps(o));
+    assert(flyd.isStream(oS));
+  });
+  it('flow unwrapped object down stream when props change', function() {
+    var oS = obj.streamProps(o);
+    var result = [];
+    flyd.map(function(o) { result.push(o); }, obj.stream(oS));
+    oS.one(4);
+    oS.three(4);
+    oS.two(4);
+    assert.deepEqual(result, [
+      {one: 1, two: 2, three: 3},
+      {one: 4, two: 2, three: 3},
+      {one: 4, two: 2, three: 4},
+      {one: 4, two: 4, three: 4},
+    ]);
+  });
+  it('handles prop changes in nested objects', function(){
+    var o = {nested: {value: 'val', deeper: {deepVal: 'deepVal'}}};
+    var oS = obj.streamProps(o);
+    var result = [];
+    flyd.map(function(o) { result.push(o); }, obj.stream(oS));
+    oS.nested.value('val2');
+    oS.nested.deeper.deepVal('deepVal2');
+    oS.nested.value('val3');
+    assert.deepEqual(result, [
+      {nested: {value: 'val', deeper: {deepVal: 'deepVal'}}},
+      {nested: {value: 'val2', deeper: {deepVal: 'deepVal'}}},
+      {nested: {value: 'val2', deeper: {deepVal: 'deepVal2'}}},
+      {nested: {value: 'val3', deeper: {deepVal: 'deepVal2'}}}
+    ]);
+  });
+  it('retains the values of non-streams', function(){
+    var oS = {nested: {value: stream('val'), deeper: {constant: 'constantVal'}}};
+    var result = [];
+    flyd.map(function(o) { result.push(o); }, obj.stream(oS));
+    oS.nested.value('val2');
+    oS.nested.value('val3');
+    assert.deepEqual(result, [
+      {nested: {value: 'val', deeper: {constant: 'constantVal'}}},
+      {nested: {value: 'val2', deeper: {constant: 'constantVal'}}},
+      {nested: {value: 'val3', deeper: {constant: 'constantVal'}}}
+    ]);
+  });
+});
+
+describe('extract', function() {
+  it('extracts the values from streams in object', function() {
+    var oS = {one: stream(1), two: stream(2), three: stream(3)};
+    var o = obj.extractProps(oS);
+    assert.equal(o.one, oS.one());
+    assert.equal(o.two, oS.two());
+    assert.equal(o.three, oS.three());
+  });
+  it('handles values that are not streams', function() {
+    var oS = {one: stream(1), undef: undefined, nll: null, two: 2};
+    var o = obj.extractProps(oS);
+    assert.equal(o.one, oS.one());
+    assert.equal(o.undef, oS.undef);
+    assert.equal(o.nll, oS.nll);
+    assert.equal(o.two, oS.two);
+  });
+  it('handles nested values', function() {
+    var oS = {nested: {value: stream('val'), deeper: {deepVal: stream('deepVal'), constant: 3}}};
+    var o = obj.extractProps(oS);
+    assert.equal(o.nested.value, oS.nested.value());
+    assert.equal(o.nested.deeper.deepVal, oS.nested.deeper.deepVal());
+    assert.equal(o.nested.deeper.constant, oS.nested.deeper.constant);
+  });
+});

--- a/module/sampleon/README.md
+++ b/module/sampleon/README.md
@@ -1,0 +1,19 @@
+# flyd-sampleon
+sampleOn for Flyd.
+
+Samples from the second stream every time an event occurs on the first
+stream.
+
+__Signature__
+
+`Stream a -> Stream b -> Stream b`
+
+__Usage__
+
+```javascript
+// Assume `sendBtnClicked` emits whenever a send button is pressed and
+// `messageText` is a stream of the current content of an input field.
+// Then `sendMessage` emits the content of the text field whenever the button
+// is pressed.
+var sendMessage = sampleOn(sendBtnClicked, messageText);
+```

--- a/module/sampleon/index.js
+++ b/module/sampleon/index.js
@@ -1,0 +1,7 @@
+var flyd = require('flyd');
+
+module.exports = flyd.curryN(2, function(s1, s2) {
+  return flyd.stream([s1], function() {
+    return s2();
+  });
+});

--- a/module/sampleon/test/index.js
+++ b/module/sampleon/test/index.js
@@ -1,0 +1,36 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+
+var sampleOn = require('../sampleon.js');
+
+describe('sample On', function() {
+  it('samples from second stream', function() {
+    var result = [];
+    var s1 = stream();
+    var s2 = stream();
+    var sampled = sampleOn(s1, s2);
+    flyd.map(function(v) {
+      result.push(v);
+    }, sampled);
+    s2(1);
+    s1(1)(2)(3);
+    s2(3)(4)(6);
+    s1(5)(3);
+    assert.deepEqual(result, [1, 1, 1, 6, 6]);
+  });
+  it('has not value until value flows on trigger stream', function() {
+    var result = [];
+    var s1 = stream();
+    var s2 = stream(1);
+    var sampled = sampleOn(s1, s2);
+    flyd.map(function(v) {
+      result.push(v);
+    }, sampled);
+    s2(1);
+    s1(1)(2)(3);
+    s2(3)(4)(6);
+    s1(5)(3);
+    assert.deepEqual(result, [1, 1, 1, 6, 6]);
+  });
+});

--- a/module/scanmerge/README.md
+++ b/module/scanmerge/README.md
@@ -1,0 +1,35 @@
+# flyd-scanmerge
+Flyd module for conveniently merging and scanning several streams into one.
+
+__Signature__
+
+`[[Stream b, (a, b -> a)]] -> a -> Stream a`
+
+__Example__
+
+```javascript
+var add = flyd.stream(0);
+var sub = flyd.stream(0);
+var mult = flyd.stream(1);
+var res = scanMerge([
+  [add, function(sum, n) { return sum + n; }],
+  [sub, function(sum, n) { return sum - n; }],
+  [mult, function(sum, n) { return sum * n; }],
+], 0);
+add(5); sub(8); sub(4); add(12); mult(3);
+console.log(res); // logs 15
+```
+
+```javascript
+var addItem = flyd.stream();
+var rmItem = flyd.stream();
+var items = scanMerge([
+  [addItem, function(list, item) { return list.concat([item]); }],
+  [rmItem, function(list, item) {
+    return list.filter(function(elm) { return elm !== item; });
+  }]
+], []);
+addItem(1)(2)(3)(4)(5);
+rmItem(3);
+console.log(items()); logs [1, 2, 4, 5]
+```

--- a/module/scanmerge/index.js
+++ b/module/scanmerge/index.js
@@ -1,0 +1,13 @@
+var flyd = require('flyd');
+
+module.exports = flyd.curryN(2, function(pairs, acc) {
+  var streams = pairs.map(function(p) { return p[0]; });
+  var fns = pairs.map(function(p) { return p[1]; });
+  return flyd.stream(streams, function(self, changed) {
+    if (changed.length > 0) {
+      var idx = streams.indexOf(changed[0]);
+      acc = fns[idx](acc, changed[0]());
+    }
+    return acc;
+  }, true);
+});

--- a/module/scanmerge/test/index.js
+++ b/module/scanmerge/test/index.js
@@ -1,0 +1,40 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+
+var scanMerge = require('../scanmerge');
+
+describe('scanMerge', function() {
+  it('scans and merges multiple streams', function() {
+    var add = stream();
+    var sub = stream();
+    var sum = scanMerge([
+      [add, function(sum, n) { return sum + n; }],
+      [sub, function(sum, n) { return sum - n; }],
+    ], 0);
+    add(5); sub(8); sub(4); add(12);
+    assert.equal(sum(), 5);
+  });
+  it('initially has initial value', function() {
+    var add = stream(2);
+    var sub = stream(4);
+    var sum = scanMerge([
+      [add, function(sum, n) { return sum + n; }],
+      [sub, function(sum, n) { return sum - n; }],
+    ], 0);
+    assert.equal(sum(), 0);
+  });
+  it('handles second example', function() {
+    var addItem = flyd.stream();
+    var rmItem = flyd.stream();
+    var items = scanMerge([
+      [addItem, function(list, item) { return list.concat([item]); }],
+      [rmItem, function(list, item) {
+        return list.filter(function(elm) { return elm !== item; });
+      }]
+    ], []);
+    addItem(1)(2)(3)(4)(5);
+    rmItem(3);
+    assert.deepEqual(items(), [1, 2, 4, 5]);
+  });
+});

--- a/module/switchlatest/README.md
+++ b/module/switchlatest/README.md
@@ -1,0 +1,19 @@
+# flyd-switchlatest
+
+Flattens a stream of streams. The result stream reflects changes from the
+last stream only.
+
+__Signature__
+
+`Stream (Stream a) -> Stream b`
+
+__Usage__
+
+```javascript
+var chatrooms = flyd.stream();
+var messagesStreams = flyd.map(function(id) {
+  return createMessageStream(id);
+}, chatrooms);
+var currentMessages = switchLatest(messagesStreams);
+```
+

--- a/module/switchlatest/index.js
+++ b/module/switchlatest/index.js
@@ -1,0 +1,11 @@
+var flyd = require('flyd');
+
+module.exports = function(s) {
+  var inner;
+  return flyd.stream([s], function(self) {
+    inner = s();
+    flyd.endsOn(flyd.merge(s, inner.end), flyd.stream([inner], function() {
+      self(inner());
+    }));
+  });
+};

--- a/module/switchlatest/test/index.js
+++ b/module/switchlatest/test/index.js
@@ -1,0 +1,43 @@
+var flyd = require('../../flyd/flyd.js');
+var stream = flyd.stream;
+var assert = require('assert');
+
+var switchLatest = require('../switchlatest.js');
+
+describe('takeUntil', function() {
+  it('emits values from first stream in stream', function() {
+    var result = [];
+    var source = stream();
+    var is = stream();
+    var s = switchLatest(source);
+    flyd.map(function(v) { result.push(v); }, s);
+    source(is);
+    is(1)(2)(3);
+    assert.deepEqual(result, [1, 2, 3]);
+  });
+  it('emits values from first and second stream in stream', function() {
+    var result = [];
+    var source = stream();
+    var is1 = stream(), is2 = stream();
+    var s = switchLatest(source);
+    flyd.map(function(v) { result.push(v); }, s);
+    source(is1);
+    is1(1);
+    source(is2);
+    is1(-1);
+    is2(2)(3);
+    assert.deepEqual(result, [1, 2, 3]);
+  });
+  it('ends when source stream ends', function() {
+    var result = [];
+    var source = stream();
+    var is = stream();
+    var s = switchLatest(source);
+    flyd.map(function(v) { result.push(v); }, s);
+    source(is); is(1)(2);
+    assert.deepEqual(result, [1, 2]);
+    assert(!source.ended);
+    source.end(true);
+    assert.equal(true, source.end());
+  });
+});

--- a/module/takeuntil/README.md
+++ b/module/takeuntil/README.md
@@ -1,0 +1,13 @@
+# flyd-takeuntil
+Emit values from a stream until a second stream emits a value.
+
+__Signature__
+
+`Stream a -> Stream b -> Stream a`
+
+__Example__
+
+```javascript
+// `s` will emit all values on `source` until `endStream` emits a value or ends
+var s = takeUntil(source, endStream);
+```

--- a/module/takeuntil/index.js
+++ b/module/takeuntil/index.js
@@ -1,0 +1,7 @@
+var flyd = require('flyd');
+
+module.exports = function(src, term) {
+  return flyd.endsOn(flyd.merge(term, src.end), flyd.stream([src], function(self) {
+    self(src());
+  }));
+};

--- a/module/takeuntil/test/index.js
+++ b/module/takeuntil/test/index.js
@@ -1,0 +1,41 @@
+var flyd = require('../../flyd/flyd.js');
+var stream = flyd.stream;
+var assert = require('assert');
+
+var takeUntil = require('../takeuntil.js');
+
+describe('takeUntil', function() {
+  it('emits values from first stream', function() {
+    var result = [];
+    var source = stream();
+    var terminator = stream();
+    var s = takeUntil(source, terminator);
+    flyd.map(function(v) { result.push(v); }, s);
+    s(1)(2)(3);
+    assert.deepEqual(result, [1, 2, 3]);
+  });
+  it('ends when value emitted from second stream', function() {
+    var result = [];
+    var source = stream();
+    var terminator = stream();
+    var s = takeUntil(source, terminator);
+    flyd.map(function(v) { result.push(v); }, s);
+    s(1);
+    terminator(true);
+    s(2);
+    assert.deepEqual(result, [1]);
+    assert(s.end());
+  });
+  it('ends if source stream ends', function() {
+    var result = [];
+    var source = stream();
+    var terminator = stream();
+    var s = takeUntil(source, terminator);
+    flyd.map(function(v) { result.push(v); }, s);
+    s(1);
+    source.end(true);
+    s(2);
+    assert.deepEqual(result, [1]);
+    assert(s.end());
+  });
+});


### PR DESCRIPTION
- I did not add modules from @ThomWright as they need ES6 preprocessing.
  We can convert and add these later.
- I also did not add flyd-keyboard as it depends on the 'keycode'
  package. This could be easily added though.
- I standardized all the module structures to have their main file be
  {module-name}/index.js and tests be under {module-name}/test. That way each module doesn't need to be only one file, and they can have their own readme's and tests.
- Touched a blank starter module/README.md file
- Left all readme's and test directories under each module.
- Removed all .git dirs, .gitignores, .npmignores, and licenses from each module dir

If you don't want to go this route and keep individual repos for every module, then I would suggest doing git submodules. They require some tricky upkeep but are really powerful. That way you can maintain each module in its own repo and you don't have to mess with publishing and updating them on npm. IMO all the modules we know are useful/commonly used should just live in the main repo, no submodules, no separate packages whatsoever.

Related issue: #32 