### PR TITLE
Added 'previous' and 'diff' modules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[*]
+indent_style = space
+indent_size = 2

--- a/module/diff/README.md
+++ b/module/diff/README.md
@@ -1,0 +1,13 @@
+# flyd-diff
+diff function for Flyd.
+
+Like map, but the mapping function gets the previous and the current value of the stream.
+
+# Usage
+```
+var velocity = flyd.stream(0);
+var acceleration = diff(function (previous, current) {
+  return current - previous;
+}, velocity);
+velocity(2)(5)(1);
+```

--- a/module/diff/index.js
+++ b/module/diff/index.js
@@ -1,0 +1,10 @@
+var flyd = require('flyd');
+
+var previous = require('flyd/module/previous');
+
+module.exports = function (diffFunc, s) {
+  var prevS = previous(s);
+  return flyd.stream([s, prevS], function (self) {
+    return diffFunc(prevS(), s());
+  });
+};

--- a/module/diff/test/index.js
+++ b/module/diff/test/index.js
@@ -1,0 +1,28 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+
+var diff = require('../diff.js');
+
+describe('diff', function() {
+  it('calls the diff function with the previous and new value', function() {
+    var s = stream(1);
+    var returnArguments = function () {
+      return Array.prototype.slice.call(arguments);
+    }
+    var d = diff(returnArguments, s);
+    s(1)(2)(3);
+    assert.deepEqual(d(), [2, 3]);
+  });
+
+  it('starts streaming after the second value is pushed into the source stream', function() {
+    var s = stream();
+    var calls = 0;
+    flyd.on();
+    var d = diff(function () { calls += 1; }, s)
+    s(1);
+    assert.equal(calls, 0);
+    s(2);
+    assert.equal(calls, 1);
+  });
+});

--- a/module/previous/README.md
+++ b/module/previous/README.md
@@ -1,0 +1,9 @@
+# flyd-previous
+previous function for Flyd.
+
+Returns a stream that is always one value behind the original stream.
+
+# Usage
+```
+var previousState = previous(state);
+```

--- a/module/previous/index.js
+++ b/module/previous/index.js
@@ -1,0 +1,18 @@
+var flyd = require('flyd');
+
+module.exports = function (s) {
+  var previousValue;
+  return flyd.stream([s], skipFirstCall(function (self) {
+    self(previousValue);
+    previousValue = s();
+  }));
+};
+
+function skipFirstCall (func) {
+  var functionToCall = function () {
+    functionToCall = func;
+  }
+  return function () {
+    return functionToCall.apply(this, arguments);
+  }
+}

--- a/module/previous/test/index.js
+++ b/module/previous/test/index.js
@@ -1,0 +1,25 @@
+var assert = require('assert');
+var flyd = require('flyd');
+var stream = flyd.stream;
+
+var previous = require('../previous.js');
+
+describe('previous', function() {
+  it('is always one value behind the source stream', function() {
+    var s = stream(1);
+    var p = previous(s);
+    s(2)(3)(4);
+    assert.equal(p(), 3);
+  });
+
+  it('starts streaming after the second value is pushed into the source stream', function() {
+    var s = stream();
+    var p = previous(s);
+    var calls = 0;
+    flyd.on(function () { calls += 1; }, p);
+    s(1);
+    assert.equal(calls, 0);
+    s(2);
+    assert.equal(calls, 1);
+  });
+});


### PR DESCRIPTION
I regularly want to create a stream that responds to changes in values in another stream. To help with that, I added two modules that I think might be interesting to others.

`flyd-previous` takes a stream and returns a stream that's always one value behind the original stream.

`flyd-diff` uses `flyd-previous` to provide a variant of `map`, in which the mapper function is called with the previous and new value of the stream.

Additionally, I took the liberty of adding a basic .editorconfig file, which I think is a great help for contributors, but if it's not liked just tell me and I'll take it out again :).

I'm looking forward to all feedback!