### PR TITLE
Promote reusable combines through dedicated `flyd.combine` function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@ logs
 
 # Dependency directory
 node_modules
-
+bower_components
 

--- a/README.md
+++ b/README.md
@@ -149,18 +149,18 @@ Naturally, a stream with dependencies can depend on other streams with dependenc
 // Create two streams of numbers
 var x = flyd.stream(4);
 var y = flyd.stream(6);
-var squareX = flyd.stream([x], function() {
+var squareX = flyd.combine(function(x) {
   return x() * x();
-});
-var squareXPlusY = flyd.stream([y, squareX], function() {
+}, [x]);
+var squareXPlusY = flyd.combine(function(y, squareX) {
   return y() + squareX();
-});
+}, [y, squareX]);
 console.log(squareXPlusY()); // logs 22
 x(2);
 console.log(squareXPlusY()); // logs 10
 ```
 
-The body of a dependent stream is called with two parameters: itself and a list
+The body of a dependent stream is called with the spread of: each dependency, itself, and a list
 of the dependencies that have changed since its last invocation (due to [atomic
 updates](#atomic-updates) several streams could have changed).
 
@@ -168,16 +168,16 @@ updates](#atomic-updates) several streams could have changed).
 // Create two streams of numbers
 var x = flyd.stream(1);
 var y = flyd.stream(2);
-var sum = flyd.stream([x, y], function(sum, changed) {
+var sum = flyd.combine(function(x, y, self, changed) {
   // The stream can read from itself
-  console.log('Last sum was ' + sum());
+  console.log('Last sum was ' + self());
   // On the initial call no streams has changed and `changed` will be []
   changed.map(function(s) {
     var changedName = (s === y ? 'y' : 'x');
     console.log(changedName + ' changed to ' + s());
   });
   return x() + y();
-});
+}, [x, y]);
 ```
 
 ### Using callback APIs for asynchronous operations
@@ -187,13 +187,13 @@ is handy when working with APIs that takes callbacks.
 
 ```javascript
 var urls = flyd.stream('/something.json');
-var responses = flyd.stream([urls], function(resp) {
-  makeRequest(urls(), resp);
-});
-flyd.stream([responses], function() {
+var responses = flyd.combine(function(urls, self) {
+  makeRequest(urls(), self);
+}, [urls]);
+flyd.combine(function(responses) {
   console.log('Received response!');
   console.log(responses());
-});
+}, [responses]);
 ```
 
 Note that the stream that logs the responses from the server should only be called
@@ -213,10 +213,10 @@ var urls = flyd.stream('/something.json');
 var responses = flyd.stream(function() {
   return requestPromise(urls());
 });
-flyd.stream([responses], function() {
+flyd.combine(function(responses) {
   console.log('Received response!');
   console.log(responses());
-});
+}, [responses]);
 ```
 
 ### Mapping over a stream
@@ -228,9 +228,9 @@ emitted by the stream. In short, a `map` function.
 
 ```javascript
 var mapStream = function(f, s) {
-  return flyd.stream([s], function() {
+  return flyd.combine(function(s) {
     return f(s());
-  });
+  }, [s]);
 };
 ```
 
@@ -247,10 +247,10 @@ look like this:
 
 ```javascript
 var scanStream = function(f, acc, s) {
-  return flyd.stream([s], function() {
+  return flyd.combine(function(s) {
     acc = f(acc, s());
     return acc;
-  });
+  }, [s]);
 };
 ```
 
@@ -283,9 +283,9 @@ the end streams of its dependencies:
 ```javascript
 var n1 = flyd.stream();
 var n2 = flyd.stream();
-var sum = flyd.stream([n1, n2], function() {
+var sum = flyd.combine(function(n1, n2) {
   return n1() + n2();
-});
+}, [n1, n2]);
 ```
 
 `sum.end` now depends on `n1.end` and `n2.end`. This means that whenever one of
@@ -296,9 +296,9 @@ You can change what a stream's end stream depends on with `flyd.endsOn`:
 ```javascript
 var number = flyd.stream(2);
 var killer = flyd.stream();
-var square = flyd.endsOn(flyd.merge(number.end, killer), flyd.stream([number], function() {
+var square = flyd.endsOn(flyd.merge(number.end, killer), flyd.stream(function(number) {
   return number() * number();
-}));
+}, [number]));
 ```
 
 Now `square` will end if either `number` ends or if `killer` emits a value.
@@ -329,21 +329,21 @@ var n = flyd.stream(1); // Stream with initial value `1`
 var s = flyd.stream(); // Stream with no initial value
 ```
 
-### flyd.stream(dependencies, body)
+### flyd.combine(body, dependencies)
 
 Creates a new dependent stream.
 
 __Signature__
 
-`[Stream *] -> (Stream b -> [Stream *] -> b) -> Stream b`
+`(...Stream * -> Stream b -> b) -> [Stream *] -> Stream b`
 
 __Example__
 ```javascript
 var n1 = flyd.stream(0);
 var n2 = flyd.stream(0);
-var max = flyd.stream([n1, n2], function(self, changed) {
+var max = flyd.combine(function(n1, n2, self, changed) {
   return n1() > n2() ? n1() : n2();
-});
+}, [n1, n2]);
 ```
 
 ###flyd.isStream(stream)
@@ -377,9 +377,9 @@ __Example__
 
 ```javascript
 var s = flyd.stream();
-var hasItems = flyd.immediate(flyd.stream([s], function() {
+var hasItems = flyd.immediate(flyd.stream(function(s) {
   return s() !== undefined && s().length > 0;
-});
+}, [s]);
 console.log(hasItems()); // logs `false`. Had `immediate` not been
                          // used `hasItems()` would've returned `undefined`
 s([1]);
@@ -402,9 +402,9 @@ __Example__
 var n = flyd.stream(1);
 var killer = flyd.stream();
 // `double` ends when `n` ends or when `killer` emits any value
-var double = flyd.endsOn(flyd.merge(n.end, killer), flyd.stream([n], function() {
+var double = flyd.endsOn(flyd.merge(n.end, killer), flyd.combine(function(n) {
   return 2 * n();
-});
+}, [n]);
 ```
 
 ###flyd.map(fn, s)
@@ -493,7 +493,7 @@ var tx = t.compose(
   t.dedupe()
 );
 var s2 = flyd.transduce(tx, s1);
-flyd.stream([s2], function() { results.push(s2()); });
+flyd.combine(function(s2) { results.push(s2()); }, [s2]);
 s1(1)(1)(2)(3)(3)(3)(4);
 results; // [2, 4, 6, 8]
 ```

--- a/examples/sum/index.html
+++ b/examples/sum/index.html
@@ -110,9 +110,9 @@
       var yBox = document.getElementById('yBox');
       x = stream(10);
       y = stream(20);
-      var sum = stream([x, y], function() {
+      var sum = flyd.combine(function(x, y) {
         return x() + y();
-      });
+      }, [x, y]);
       flyd.map(function(sum) {
         sumBox.innerHTML = sum;
       }, sum);
@@ -195,9 +195,9 @@
       <h2>Source code</h2>
       <code class="code-block">var x = stream(10);
 var y = stream(20);
-var sum = stream([x, y], function() {
+var sum = flyd.combine(function(x, y) {
   return x() + y();
-});
+}, [x, y]);
 var elm = document.getElementById('sumBox');
 flyd.map(function(s) {
   elm.innerHTML = s;

--- a/flyd.js
+++ b/flyd.js
@@ -1,4 +1,4 @@
-!function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.flyd=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+(function(f){if(typeof exports==="object"&&typeof module!=="undefined"){module.exports=f()}else if(typeof define==="function"&&define.amd){define([],f)}else{var g;if(typeof window!=="undefined"){g=window}else if(typeof global!=="undefined"){g=global}else if(typeof self!=="undefined"){g=self}else{g=this}g.flyd = f()}})(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 var curryN = require('ramda/src/curryN');
 
 'use strict';
@@ -16,7 +16,7 @@ function map(f, s) {
 }
 
 function on(f, s) {
-  stream([s], function() { f(s.val); });
+  return stream([s], function() { f(s.val); });
 }
 
 function boundMap(f) { return map(f, this); }
@@ -61,7 +61,8 @@ function updateStream(s) {
     return;
   }
   inStream = s;
-  var returnVal = s.fn(s, s.depsChanged);
+  s.fnArgs[1] = s.depsChanged;
+  var returnVal = s.fn.apply(s.fn, s.fnArgs);
   if (returnVal !== undefined) {
     s(returnVal);
   }
@@ -191,6 +192,7 @@ function createDependentStream(deps, fn) {
   s.depsMet = false;
   s.depsChanged = fn.length > 1 ? [] : undefined;
   s.shouldUpdate = false;
+  s.fnArgs = [s, s.depsChanged].concat(s.deps);
   addListeners(deps, s);
   return s;
 }
@@ -287,85 +289,11 @@ module.exports = {
   immediate: immediate,
 };
 
-},{"ramda/src/curryN":4}],2:[function(require,module,exports){
-/**
- * A special placeholder value used to specify "gaps" within curried functions,
- * allowing partial application of any combination of arguments,
- * regardless of their positions.
- *
- * If `g` is a curried ternary function and `_` is `R.__`, the following are equivalent:
- *
- *   - `g(1, 2, 3)`
- *   - `g(_, 2, 3)(1)`
- *   - `g(_, _, 3)(1)(2)`
- *   - `g(_, _, 3)(1, 2)`
- *   - `g(_, 2, _)(1, 3)`
- *   - `g(_, 2)(1)(3)`
- *   - `g(_, 2)(1, 3)`
- *   - `g(_, 2)(_, 3)(1)`
- *
- * @constant
- * @memberOf R
- * @category Function
- * @example
- *
- *      var greet = R.replace('{name}', R.__, 'Hello, {name}!');
- *      greet('Alice'); //=> 'Hello, Alice!'
- */
-module.exports = {ramda: 'placeholder'};
-
-},{}],3:[function(require,module,exports){
+},{"ramda/src/curryN":2}],2:[function(require,module,exports){
+var _arity = require('./internal/_arity');
+var _curry1 = require('./internal/_curry1');
 var _curry2 = require('./internal/_curry2');
-
-
-/**
- * Wraps a function of any arity (including nullary) in a function that accepts exactly `n`
- * parameters. Unlike `nAry`, which passes only `n` arguments to the wrapped function,
- * functions produced by `arity` will pass all provided arguments to the wrapped function.
- *
- * @func
- * @memberOf R
- * @sig (Number, (* -> *)) -> (* -> *)
- * @category Function
- * @param {Number} n The desired arity of the returned function.
- * @param {Function} fn The function to wrap.
- * @return {Function} A new function wrapping `fn`. The new function is
- *         guaranteed to be of arity `n`.
- * @example
- *
- *      var takesTwoArgs = function(a, b) {
- *        return [a, b];
- *      };
- *      takesTwoArgs.length; //=> 2
- *      takesTwoArgs(1, 2); //=> [1, 2]
- *
- *      var takesOneArg = R.arity(1, takesTwoArgs);
- *      takesOneArg.length; //=> 1
- *      // All arguments are passed through to the wrapped function
- *      takesOneArg(1, 2); //=> [1, 2]
- */
-module.exports = _curry2(function(n, fn) {
-  switch (n) {
-    case 0: return function() {return fn.apply(this, arguments);};
-    case 1: return function(a0) {void a0; return fn.apply(this, arguments);};
-    case 2: return function(a0, a1) {void a1; return fn.apply(this, arguments);};
-    case 3: return function(a0, a1, a2) {void a2; return fn.apply(this, arguments);};
-    case 4: return function(a0, a1, a2, a3) {void a3; return fn.apply(this, arguments);};
-    case 5: return function(a0, a1, a2, a3, a4) {void a4; return fn.apply(this, arguments);};
-    case 6: return function(a0, a1, a2, a3, a4, a5) {void a5; return fn.apply(this, arguments);};
-    case 7: return function(a0, a1, a2, a3, a4, a5, a6) {void a6; return fn.apply(this, arguments);};
-    case 8: return function(a0, a1, a2, a3, a4, a5, a6, a7) {void a7; return fn.apply(this, arguments);};
-    case 9: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8) {void a8; return fn.apply(this, arguments);};
-    case 10: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) {void a9; return fn.apply(this, arguments);};
-    default: throw new Error('First argument to arity must be a non-negative integer no greater than ten');
-  }
-});
-
-},{"./internal/_curry2":6}],4:[function(require,module,exports){
-var __ = require('./__');
-var _curry2 = require('./internal/_curry2');
-var _slice = require('./internal/_slice');
-var arity = require('./arity');
+var _curryN = require('./internal/_curryN');
 
 
 /**
@@ -412,37 +340,32 @@ var arity = require('./arity');
  *      g(4); //=> 10
  */
 module.exports = _curry2(function curryN(length, fn) {
-  return arity(length, function() {
-    var n = arguments.length;
-    var shortfall = length - n;
-    var idx = n;
-    while (--idx >= 0) {
-      if (arguments[idx] === __) {
-        shortfall += 1;
-      }
-    }
-    if (shortfall <= 0) {
-      return fn.apply(this, arguments);
-    } else {
-      var initialArgs = _slice(arguments);
-      return curryN(shortfall, function() {
-        var currentArgs = _slice(arguments);
-        var combinedArgs = [];
-        var idx = -1;
-        while (++idx < n) {
-          var val = initialArgs[idx];
-          combinedArgs[idx] = (val === __ ? currentArgs.shift() : val);
-        }
-        return fn.apply(this, combinedArgs.concat(currentArgs));
-      });
-    }
-  });
+  if (length === 1) {
+    return _curry1(fn);
+  }
+  return _arity(length, _curryN(length, [], fn));
 });
 
-},{"./__":2,"./arity":3,"./internal/_curry2":6,"./internal/_slice":7}],5:[function(require,module,exports){
-var __ = require('../__');
+},{"./internal/_arity":3,"./internal/_curry1":4,"./internal/_curry2":5,"./internal/_curryN":6}],3:[function(require,module,exports){
+module.exports = function _arity(n, fn) {
+  // jshint unused:vars
+  switch (n) {
+    case 0: return function() { return fn.apply(this, arguments); };
+    case 1: return function(a0) { return fn.apply(this, arguments); };
+    case 2: return function(a0, a1) { return fn.apply(this, arguments); };
+    case 3: return function(a0, a1, a2) { return fn.apply(this, arguments); };
+    case 4: return function(a0, a1, a2, a3) { return fn.apply(this, arguments); };
+    case 5: return function(a0, a1, a2, a3, a4) { return fn.apply(this, arguments); };
+    case 6: return function(a0, a1, a2, a3, a4, a5) { return fn.apply(this, arguments); };
+    case 7: return function(a0, a1, a2, a3, a4, a5, a6) { return fn.apply(this, arguments); };
+    case 8: return function(a0, a1, a2, a3, a4, a5, a6, a7) { return fn.apply(this, arguments); };
+    case 9: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8) { return fn.apply(this, arguments); };
+    case 10: return function(a0, a1, a2, a3, a4, a5, a6, a7, a8, a9) { return fn.apply(this, arguments); };
+    default: throw new Error('First argument to _arity must be a non-negative integer no greater than ten');
+  }
+};
 
-
+},{}],4:[function(require,module,exports){
 /**
  * Optimized internal two-arity curry function.
  *
@@ -455,16 +378,15 @@ module.exports = function _curry1(fn) {
   return function f1(a) {
     if (arguments.length === 0) {
       return f1;
-    } else if (a === __) {
+    } else if (a != null && a['@@functional/placeholder'] === true) {
       return f1;
     } else {
-      return fn(a);
+      return fn.apply(this, arguments);
     }
   };
 };
 
-},{"../__":2}],6:[function(require,module,exports){
-var __ = require('../__');
+},{}],5:[function(require,module,exports){
 var _curry1 = require('./_curry1');
 
 
@@ -481,15 +403,16 @@ module.exports = function _curry2(fn) {
     var n = arguments.length;
     if (n === 0) {
       return f2;
-    } else if (n === 1 && a === __) {
+    } else if (n === 1 && a != null && a['@@functional/placeholder'] === true) {
       return f2;
     } else if (n === 1) {
       return _curry1(function(b) { return fn(a, b); });
-    } else if (n === 2 && a === __ && b === __) {
+    } else if (n === 2 && a != null && a['@@functional/placeholder'] === true &&
+                          b != null && b['@@functional/placeholder'] === true) {
       return f2;
-    } else if (n === 2 && a === __) {
+    } else if (n === 2 && a != null && a['@@functional/placeholder'] === true) {
       return _curry1(function(a) { return fn(a, b); });
-    } else if (n === 2 && b === __) {
+    } else if (n === 2 && b != null && b['@@functional/placeholder'] === true) {
       return _curry1(function(b) { return fn(a, b); });
     } else {
       return fn(a, b);
@@ -497,38 +420,45 @@ module.exports = function _curry2(fn) {
   };
 };
 
-},{"../__":2,"./_curry1":5}],7:[function(require,module,exports){
+},{"./_curry1":4}],6:[function(require,module,exports){
+var _arity = require('./_arity');
+
+
 /**
- * An optimized, private array `slice` implementation.
+ * Internal curryN function.
  *
  * @private
- * @param {Arguments|Array} args The array or arguments object to consider.
- * @param {Number} [from=0] The array index to slice from, inclusive.
- * @param {Number} [to=args.length] The array index to slice to, exclusive.
- * @return {Array} A new, sliced array.
- * @example
- *
- *      _slice([1, 2, 3, 4, 5], 1, 3); //=> [2, 3]
- *
- *      var firstThreeArgs = function(a, b, c, d) {
- *        return _slice(arguments, 0, 3);
- *      };
- *      firstThreeArgs(1, 2, 3, 4); //=> [1, 2, 3]
+ * @category Function
+ * @param {Number} length The arity of the curried function.
+ * @return {array} An array of arguments received thus far.
+ * @param {Function} fn The function to curry.
  */
-module.exports = function _slice(args, from, to) {
-  switch (arguments.length) {
-    case 1: return _slice(args, 0, args.length);
-    case 2: return _slice(args, from, args.length);
-    default:
-      var list = [];
-      var idx = -1;
-      var len = Math.max(0, Math.min(args.length, to) - from);
-      while (++idx < len) {
-        list[idx] = args[from + idx];
+module.exports = function _curryN(length, received, fn) {
+  return function() {
+    var combined = [];
+    var argsIdx = 0;
+    var left = length;
+    var combinedIdx = 0;
+    while (combinedIdx < received.length || argsIdx < arguments.length) {
+      var result;
+      if (combinedIdx < received.length &&
+          (received[combinedIdx] == null ||
+           received[combinedIdx]['@@functional/placeholder'] !== true ||
+           argsIdx >= arguments.length)) {
+        result = received[combinedIdx];
+      } else {
+        result = arguments[argsIdx];
+        argsIdx += 1;
       }
-      return list;
-  }
+      combined[combinedIdx] = result;
+      if (result == null || result['@@functional/placeholder'] !== true) {
+        left -= 1;
+      }
+      combinedIdx += 1;
+    }
+    return left <= 0 ? fn.apply(this, combined) : _arity(left, _curryN(length, combined, fn));
+  };
 };
 
-},{}]},{},[1])(1)
+},{"./_arity":3}]},{},[1])(1)
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -60,7 +60,8 @@ function updateStream(s) {
     return;
   }
   inStream = s;
-  var returnVal = s.fn(s, s.depsChanged);
+  s.fnArgs[1] = s.depsChanged;
+  var returnVal = s.fn.apply(s.fn, s.fnArgs);
   if (returnVal !== undefined) {
     s(returnVal);
   }
@@ -190,6 +191,7 @@ function createDependentStream(deps, fn) {
   s.depsMet = false;
   s.depsChanged = fn.length > 1 ? [] : undefined;
   s.shouldUpdate = false;
+  s.fnArgs = [s, s.depsChanged].concat(s.deps);
   addListeners(deps, s);
   return s;
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -190,8 +190,7 @@ function createDependentStream(deps, fn) {
   s.fn = fn;
   s.deps = deps;
   s.depsMet = false;
-  // @todo: Does fn.length break this in some cases?
-  s.depsChanged = deps.length + 1 === fn.length ? [] : undefined;
+  s.depsChanged = deps.length > 0 ? [] : undefined;
   s.shouldUpdate = false;
   addListeners(deps, s);
   return s;

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,17 +11,17 @@ var toUpdate = [];
 var inStream;
 
 function map(f, s) {
-  return stream([s], function(self) { self(f(s.val)); });
+  return combine([s], function(s, self) { self(f(s.val)); });
 }
 
 function on(f, s) {
-  return stream([s], function() { f(s.val); });
+  return combine([s], function(s) { f(s.val); });
 }
 
 function boundMap(f) { return map(f, this); }
 
 var scan = curryN(3, function(f, acc, s) {
-  var ns = stream([s], function() {
+  var ns = combine([s], function() {
     return (acc = f(acc, s()));
   });
   if (!ns.hasVal) ns(acc);
@@ -29,12 +29,12 @@ var scan = curryN(3, function(f, acc, s) {
 });
 
 var merge = curryN(2, function(s1, s2) {
-  var s = immediate(stream([s1, s2], function(n, changed) {
+  var s = immediate(combine([s1, s2], function(s1, s2, n, changed) {
     return changed[0] ? changed[0]()
          : s1.hasVal  ? s1()
                       : s2();
   }));
-  endsOn(stream([s1.end, s2.end], function(self, changed) {
+  endsOn(combine([s1.end, s2.end], function() {
     return true;
   }), s);
   return s;
@@ -42,7 +42,7 @@ var merge = curryN(2, function(s1, s2) {
 
 function ap(s2) {
   var s1 = this;
-  return stream([s1, s2], function() { return s1()(s2()); });
+  return combine([s1, s2], function() { return s1()(s2()); });
 }
 
 function initialDepsNotMet(stream) {
@@ -60,8 +60,12 @@ function updateStream(s) {
     return;
   }
   inStream = s;
-  s.fnArgs[1] = s.depsChanged;
-  var returnVal = s.fn.apply(s.fn, s.fnArgs);
+  // Update fnArgs if set -- @todo: remove guard after deprecation
+  if (s.fnArgs)
+  {
+    s.fnArgs[s.fnArgs.length - 1] = s.depsChanged;
+  }
+  var returnVal = s.fnArgs ? s.fn.apply(s.fn, s.fnArgs) : s.fn(s, s.depsChanged);
   if (returnVal !== undefined) {
     s(returnVal);
   }
@@ -189,9 +193,8 @@ function createDependentStream(deps, fn) {
   s.fn = fn;
   s.deps = deps;
   s.depsMet = false;
-  s.depsChanged = fn.length > 1 ? [] : undefined;
+  s.depsChanged = fn.length === deps.length + 2 ? [] : undefined;
   s.shouldUpdate = false;
-  s.fnArgs = [s, s.depsChanged].concat(s.deps);
   addListeners(deps, s);
   return s;
 }
@@ -234,6 +237,7 @@ function trueFn() { return true; }
 function stream(arg, fn) {
   var i, s, deps, depEndStreams;
   var endStream = createDependentStream([], trueFn);
+  // @deprecated in favor of flyd.combine
   if (arguments.length > 1) {
     deps = []; depEndStreams = [];
     for (i = 0; i < arg.length; ++i) {
@@ -257,9 +261,29 @@ function stream(arg, fn) {
   return s;
 }
 
+function combine(streams, fn) {
+  var i, s, deps, depEndStreams;
+  var endStream = createDependentStream([], trueFn);
+  deps = []; depEndStreams = [];
+  for (i = 0; i < streams.length; ++i) {
+    if (streams[i] !== undefined) {
+      deps.push(streams[i]);
+      if (streams[i].end !== undefined) depEndStreams.push(streams[i].end);
+    }
+  }
+  s = createDependentStream(deps, fn);
+  s.fnArgs = s.deps.concat([s, s.depsChanged]);
+  s.end = endStream;
+  endStream.listeners.push(s);
+  addListeners(depEndStreams, endStream);
+  endStream.deps = depEndStreams;
+  updateStream(s);
+  return s;
+}
+
 var transduce = curryN(2, function(xform, source) {
   xform = xform(new StreamTransformer());
-  return stream([source], function(self) {
+  return combine([source], function(self) {
     var res = xform['@@transducer/step'](undefined, source());
     if (res && res['@@transducer/reduced'] === true) {
       self.end(true);
@@ -277,6 +301,7 @@ StreamTransformer.prototype['@@transducer/step'] = function(s, v) { return v; };
 
 module.exports = {
   stream: stream,
+  combine: combine,
   isStream: isStream,
   transduce: transduce,
   merge: merge,

--- a/lib/index.js
+++ b/lib/index.js
@@ -193,7 +193,8 @@ function createDependentStream(deps, fn) {
   s.fn = fn;
   s.deps = deps;
   s.depsMet = false;
-  s.depsChanged = fn.length === deps.length + 2 ? [] : undefined;
+  // @todo: with combine signiture, replace with deps.length + 1 === fn.length
+  s.depsChanged = fn.length > 1 ? [] : undefined;
   s.shouldUpdate = false;
   addListeners(deps, s);
   return s;
@@ -272,6 +273,7 @@ function combine(streams, fn) {
     }
   }
   s = createDependentStream(deps, fn);
+  s.depsChanged = [];
   s.fnArgs = s.deps.concat([s, s.depsChanged]);
   s.end = endStream;
   endStream.listeners.push(s);

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,39 +10,40 @@ function isFunction(obj) {
 var toUpdate = [];
 var inStream;
 
+// Library functions use self callback to accept (null, undefined) update triggers.
 function map(f, s) {
-  return combine([s], function(s, self) { self(f(s.val)); });
+  return combine(function(s, self) { self(f(s.val)); }, [s]);
 }
 
 function on(f, s) {
-  return combine([s], function(s) { f(s.val); });
+  return combine(function(s) { f(s.val); }, [s]);
 }
 
 function boundMap(f) { return map(f, this); }
 
 var scan = curryN(3, function(f, acc, s) {
-  var ns = combine([s], function() {
-    return (acc = f(acc, s()));
-  });
+  var ns = combine(function(s, self) {
+    return (acc = f(acc, s.val));
+  }, [s]);
   if (!ns.hasVal) ns(acc);
   return ns;
 });
 
 var merge = curryN(2, function(s1, s2) {
-  var s = immediate(combine([s1, s2], function(s1, s2, n, changed) {
+  var s = immediate(combine(function(s1, s2, self, changed) {
     return changed[0] ? changed[0]()
-         : s1.hasVal  ? s1()
-                      : s2();
-  }));
-  endsOn(combine([s1.end, s2.end], function() {
+         : s1.hasVal  ? s1.val
+                      : s2.val;
+  }, [s1, s2]));
+  endsOn(combine(function() {
     return true;
-  }), s);
+  }, [s1.end, s2.end]), s);
   return s;
 });
 
 function ap(s2) {
   var s1 = this;
-  return combine([s1, s2], function() { return s1()(s2()); });
+  return combine(function(s1, s2, self) { self(s1.val(s2.val)); }, [s1, s2]);
 }
 
 function initialDepsNotMet(stream) {
@@ -60,12 +61,8 @@ function updateStream(s) {
     return;
   }
   inStream = s;
-  // Update fnArgs if set -- @todo: remove guard after deprecation
-  if (s.fnArgs)
-  {
-    s.fnArgs[s.fnArgs.length - 1] = s.depsChanged;
-  }
-  var returnVal = s.fnArgs ? s.fn.apply(s.fn, s.fnArgs) : s.fn(s, s.depsChanged);
+  if (s.depsChanged) s.fnArgs[s.fnArgs.length - 1] = s.depsChanged;
+  var returnVal = s.fn.apply(s.fn, s.fnArgs);
   if (returnVal !== undefined) {
     s(returnVal);
   }
@@ -193,8 +190,8 @@ function createDependentStream(deps, fn) {
   s.fn = fn;
   s.deps = deps;
   s.depsMet = false;
-  // @todo: with combine signiture, replace with deps.length + 1 === fn.length
-  s.depsChanged = fn.length > 1 ? [] : undefined;
+  // @todo: Does fn.length break this in some cases?
+  s.depsChanged = deps.length + 1 === fn.length ? [] : undefined;
   s.shouldUpdate = false;
   addListeners(deps, s);
   return s;
@@ -235,34 +232,17 @@ function endsOn(endS, s) {
 
 function trueFn() { return true; }
 
-function stream(arg, fn) {
-  var i, s, deps, depEndStreams;
+function stream(initialValue) {
   var endStream = createDependentStream([], trueFn);
-  // @deprecated in favor of flyd.combine
-  if (arguments.length > 1) {
-    deps = []; depEndStreams = [];
-    for (i = 0; i < arg.length; ++i) {
-      if (arg[i] !== undefined) {
-        deps.push(arg[i]);
-        if (arg[i].end !== undefined) depEndStreams.push(arg[i].end);
-      }
-    }
-    s = createDependentStream(deps, fn);
-    s.end = endStream;
-    endStream.listeners.push(s);
-    addListeners(depEndStreams, endStream);
-    endStream.deps = depEndStreams;
-    updateStream(s);
-  } else {
-    s = createStream();
-    s.end = endStream;
-    endStream.listeners.push(s);
-    if (arguments.length === 1) s(arg);
-  }
+  var s = createStream();
+  s.end = endStream;
+  s.fnArgs = [];
+  endStream.listeners.push(s);
+  if (arguments.length > 0) s(initialValue);
   return s;
 }
 
-function combine(streams, fn) {
+function combine(fn, streams) {
   var i, s, deps, depEndStreams;
   var endStream = createDependentStream([], trueFn);
   deps = []; depEndStreams = [];
@@ -285,15 +265,15 @@ function combine(streams, fn) {
 
 var transduce = curryN(2, function(xform, source) {
   xform = xform(new StreamTransformer());
-  return combine([source], function(self) {
-    var res = xform['@@transducer/step'](undefined, source());
+  return combine(function(source, self) {
+    var res = xform['@@transducer/step'](undefined, source.val);
     if (res && res['@@transducer/reduced'] === true) {
       self.end(true);
       return res['@@transducer/value'];
     } else {
       return res;
     }
-  });
+  }, [source]);
 });
 
 function StreamTransformer() { }
@@ -303,7 +283,7 @@ StreamTransformer.prototype['@@transducer/step'] = function(s, v) { return v; };
 
 module.exports = {
   stream: stream,
-  combine: combine,
+  combine: curryN(2, combine),
   isStream: isStream,
   transduce: transduce,
   merge: merge,

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ function boundMap(f) { return map(f, this); }
 
 var scan = curryN(3, function(f, acc, s) {
   var ns = combine(function(s, self) {
-    return (acc = f(acc, s.val));
+    self(acc = f(acc, s.val));
   }, [s]);
   if (!ns.hasVal) ns(acc);
   return ns;
@@ -31,9 +31,13 @@ var scan = curryN(3, function(f, acc, s) {
 
 var merge = curryN(2, function(s1, s2) {
   var s = immediate(combine(function(s1, s2, self, changed) {
-    return changed[0] ? changed[0]()
-         : s1.hasVal  ? s1.val
-                      : s2.val;
+    if (changed[0]) {
+      self(changed[0]());
+    } else if (s1.hasVal) {
+      self(s1.val);
+    } else if (s2.hasVal) {
+      self(s2.val);
+    }
   }, [s1, s2]));
   endsOn(combine(function() {
     return true;

--- a/module/aftersilence/index.js
+++ b/module/aftersilence/index.js
@@ -1,14 +1,14 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
-module.exports = function(dur, s) {
+module.exports = flyd.curryN(2, function(dur, s) {
   var scheduled;
   var buffer = [];
-  return flyd.stream([s], function(self) {
+  return flyd.combine(function(s, self) {
     buffer.push(s());
     clearTimeout(scheduled);
     scheduled = setTimeout(function() {
       self(buffer);
       buffer = [];
     }, dur);
-  });
-};
+  }, [s]);
+});

--- a/module/aftersilence/test/index.js
+++ b/module/aftersilence/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('../../../flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 
 var afterSilence = require('../index.js');

--- a/module/diff/index.js
+++ b/module/diff/index.js
@@ -1,10 +1,10 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 var previous = require('../previous');
 
 module.exports = function (diffFunc, s) {
   var prevS = previous(s);
-  return flyd.stream([s, prevS], function (self) {
+  return flyd.combine(function (self) {
     return diffFunc(prevS(), s());
-  });
+  }, [s, prevS]);
 };

--- a/module/diff/test/index.js
+++ b/module/diff/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('../../../flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 
 var diff = require('../index.js');

--- a/module/droprepeats/index.js
+++ b/module/droprepeats/index.js
@@ -1,13 +1,13 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 function dropRepeatsWith(eq, s) {
   var prev;
-  return flyd.stream([s], function(self) {
+  return flyd.combine(function(s, self) {
     if (!eq(s.val, prev)) {
       self(s.val);
       prev = s.val;
     }
-  });
+  }, [s]);
 }
 
 exports.dropRepeats = function(s) {

--- a/module/droprepeats/test/index.js
+++ b/module/droprepeats/test/index.js
@@ -1,9 +1,9 @@
-var flyd = require('../../../flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 var dropRepeats = require('../').dropRepeats;
 var dropRepeatsWith = require('../').dropRepeatsWith;
 var R = require('ramda');
-var assert = require('chai').assert;
+var assert = require('assert');
 
 var collect = flyd.scan(R.flip(R.append), []);
 

--- a/module/every/index.js
+++ b/module/every/index.js
@@ -1,4 +1,4 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = function(dur) {
   var s = flyd.stream();

--- a/module/every/test/index.js
+++ b/module/every/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('../../../flyd');
+var flyd = require('../../../lib');
 var every = require('../index.js');
 
 describe('every', function() {

--- a/module/filter/index.js
+++ b/module/filter/index.js
@@ -1,7 +1,7 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = flyd.curryN(2, function(fn, s) {
-  return flyd.stream([s], function(self) {
+  return flyd.combine(function(s, self) {
     if (fn(s())) self(s.val);
-  });
+  }, [s]);
 });

--- a/module/filter/test/index.js
+++ b/module/filter/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('../../../flyd');
+var flyd = require('../../../lib');
 
 var filter = require('../index.js');
 

--- a/module/flatmap/index.js
+++ b/module/flatmap/index.js
@@ -1,7 +1,7 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = function(f, s) {
-  return flyd.stream([s], function(own) {
+  return flyd.combine(function(s, own) {
     flyd.map(own, f(s()));
-  });
+  }, [s]);
 };

--- a/module/forwardto/index.js
+++ b/module/forwardto/index.js
@@ -1,4 +1,4 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = flyd.curryN(2, function(targ, fn) {
   var s = flyd.stream();

--- a/module/forwardto/test/index.js
+++ b/module/forwardto/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('../../../flyd');
+var flyd = require('../../../lib');
 var forwardTo = require('../index.js');
 
 describe('forwardTo', function() {

--- a/module/inlast/index.js
+++ b/module/inlast/index.js
@@ -1,11 +1,11 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = flyd.curryN(2, function(dur, s) {
   var values = [];
-  return flyd.stream([s], function(self) {
+  return flyd.combine(function(s, self) {
     setTimeout(function() {
       self(values = values.slice(1));
     }, dur);
     return (values = values.concat([s()]));
-  });
+  }, [s]);
 });

--- a/module/inlast/test/index.js
+++ b/module/inlast/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('../../flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 
 var inLast = require('../index.js');

--- a/module/keepwhen/index.js
+++ b/module/keepwhen/index.js
@@ -1,8 +1,8 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 // Stream bool -> Stream a -> Stream a
 module.exports = flyd.curryN(2, function(sBool, sA) {
-  return flyd.stream([sA], function(self) {
+  return flyd.combine(function(sA, self) {
     if (sBool() !== false) self(sA());
-  });
+  }, [sA]);
 });

--- a/module/keepwhen/test/index.js
+++ b/module/keepwhen/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 
 var keepWhen = require('../index.js');

--- a/module/lift/index.js
+++ b/module/lift/index.js
@@ -1,10 +1,10 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = function(f /* , streams */) {
   var streams = Array.prototype.slice.call(arguments, 1);
   var vals = [];
-  return flyd.stream(streams, function() {
+  return flyd.combine(function() {
     for (var i = 0; i < streams.length; ++i) vals[i] = streams[i]();
     return f.apply(null, vals);
-  });
+  }, streams);
 };

--- a/module/lift/test/index.js
+++ b/module/lift/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 var lift = require('../index.js');
 

--- a/module/obj/index.js
+++ b/module/obj/index.js
@@ -1,4 +1,4 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 function isPlainObject(obj) {
   return obj !== null && typeof obj === 'object' && Object.getPrototypeOf(obj) === Object.prototype;
@@ -32,9 +32,9 @@ var stream = function(obj) {
          : flyd.isStream(obj[key]) ? obj[key]
                                    : flyd.stream(obj[key]);
   });
-  return flyd.stream(streams, function() {
+  return flyd.combine(function() {
     return extractProps(obj);
-  });
+  }, streams);
 };
 
 module.exports = {

--- a/module/obj/test/index.js
+++ b/module/obj/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 
 var obj = require('../index.js');

--- a/module/previous/index.js
+++ b/module/previous/index.js
@@ -1,11 +1,11 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = function (s) {
   var previousValue;
-  return flyd.stream([s], skipFirstCall(function (self) {
+  return flyd.combine(skipFirstCall(function(s, self) {
     self(previousValue);
     previousValue = s();
-  }));
+  }), [s]);
 };
 
 function skipFirstCall (func) {

--- a/module/previous/test/index.js
+++ b/module/previous/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 
 var previous = require('../index.js');

--- a/module/sampleon/index.js
+++ b/module/sampleon/index.js
@@ -1,7 +1,7 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = flyd.curryN(2, function(s1, s2) {
-  return flyd.stream([s1], function() {
+  return flyd.combine(function(s1) {
     return s2();
-  });
+  }, [s1]);
 });

--- a/module/sampleon/test/index.js
+++ b/module/sampleon/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 
 var sampleOn = require('../index.js');

--- a/module/scanmerge/index.js
+++ b/module/scanmerge/index.js
@@ -1,13 +1,25 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = flyd.curryN(2, function(pairs, acc) {
-  var streams = pairs.map(function(p) { return p[0]; });
-  var fns = pairs.map(function(p) { return p[1]; });
-  return flyd.stream(streams, function(self, changed) {
-    if (changed.length > 0) {
-      var idx = streams.indexOf(changed[0]);
-      acc = fns[idx](acc, changed[0]());
-    }
-    return acc;
-  }, true);
+  // The scanMerged stream and accumulator
+  var scanMerged = flyd.stream();
+  
+  // update scanMerged with any function/stream pair
+  // @todo: make atomic currently in order of register in scanMerged.
+  var onStream = flyd.on(function(valAndFn){
+    scanMerged(valAndFn[1](scanMerged(), valAndFn[0]));
+  });
+  
+  var streamsWithFn = pairs.map(function(streamAndFn) {
+    return streamAndFn[0].map(function(x) {
+      return [x, streamAndFn[1]];
+    });
+  });
+  
+  streamsWithFn.map(onStream);
+  
+  // Enforce initial value
+  scanMerged(acc);
+  
+  return scanMerged;
 });

--- a/module/scanmerge/test/index.js
+++ b/module/scanmerge/test/index.js
@@ -1,5 +1,5 @@
 var assert = require('assert');
-var flyd = require('flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 
 var scanMerge = require('../index');

--- a/module/switchlatest/index.js
+++ b/module/switchlatest/index.js
@@ -1,11 +1,11 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = function(s) {
   var inner;
-  return flyd.stream([s], function(self) {
+  return flyd.combine(function(s, self) {
     inner = s();
-    flyd.endsOn(flyd.merge(s, inner.end), flyd.stream([inner], function() {
+    flyd.endsOn(flyd.merge(s, inner.end), flyd.combine(function(inner) {
       self(inner());
-    }));
-  });
+    }, [inner]));
+  }, [s]);
 };

--- a/module/switchlatest/test/index.js
+++ b/module/switchlatest/test/index.js
@@ -1,4 +1,4 @@
-var flyd = require('../../../flyd');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 var assert = require('assert');
 

--- a/module/takeuntil/index.js
+++ b/module/takeuntil/index.js
@@ -1,7 +1,7 @@
-var flyd = require('flyd');
+var flyd = require('../../lib');
 
 module.exports = function(src, term) {
-  return flyd.endsOn(flyd.merge(term, src.end), flyd.stream([src], function(self) {
+  return flyd.endsOn(flyd.merge(term, src.end), flyd.combine(function(src, self) {
     self(src());
-  }));
+  }, [src]));
 };

--- a/module/takeuntil/test/index.js
+++ b/module/takeuntil/test/index.js
@@ -1,8 +1,8 @@
-var flyd = require('../../flyd/flyd.js');
+var flyd = require('../../../lib');
 var stream = flyd.stream;
 var assert = require('assert');
 
-var takeUntil = require('../takeuntil.js');
+var takeUntil = require('../index');
 
 describe('takeUntil', function() {
   it('emits values from first stream', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -740,20 +740,17 @@ describe('stream', function() {
     });
     it('should call dependent streams with dependencies', function()
     {
-      var result = [];
       var a = flyd.stream();
       var b = flyd.stream(0);
-      var dependent = flyd.stream([a, b], function(d, changed, a, b)
-      {
-        result.push(a());
-        result.push(b());
-      });
-      a(1)(2);
-      b(3);
-      a(4);
-      assert.deepEqual(result, [
+      var collect = function(self, changed, x, y){ return (self() || []).concat([x(), y()]); };
+
+      var history = flyd.stream([a, b], collect);
+      a(1)(2); // [1, 0, 2, 0]
+      b(3);    // [1, 0, 2, 0, 2, 3]
+      a(4);    // [1, 0, 2, 0, 2, 3, 4, 3]
+      assert.deepEqual(history(), [
         1, 0, 2, 0, 2, 3, 4, 3
       ]);
-    })
+    });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -482,6 +482,15 @@ describe('stream', function() {
       s2(15);
       assert.equal(merged(), 15);
     });
+    it('should work for s1 being defined first', function(){
+      var s1 = stream(undefined);
+      var s2 = stream();
+      var merged = flyd.merge(s1, s2);
+      assert.equal(merged(), undefined);
+      
+      s1(25);
+      assert.equal(merged(), 25);
+    });
     it('ends only when both merged streams have ended', function() {
       var result = [];
       var s1 = stream();

--- a/test/index.js
+++ b/test/index.js
@@ -738,5 +738,22 @@ describe('stream', function() {
         [], [1, 3, 2], [2, 8, 7, 6], [3, 5, 4]
       ]);
     });
+    it('should call dependent streams with dependencies', function()
+    {
+      var result = [];
+      var a = flyd.stream();
+      var b = flyd.stream(0);
+      var dependent = flyd.stream([a, b], function(d, changed, a, b)
+      {
+        result.push(a());
+        result.push(b());
+      });
+      a(1)(2);
+      b(3);
+      a(4);
+      assert.deepEqual(result, [
+        1, 0, 2, 0, 2, 3, 4, 3
+      ]);
+    })
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -432,6 +432,16 @@ describe('stream', function() {
       numbers(3)(2)(4)(10);
       assert.equal(sum(), 19);
     });
+    it('passes undefined', function() {
+      var x = stream();
+      var scan = flyd.scan(function(acc, x){
+        return acc.concat([x]);
+      }, [], x);
+      
+      x(1)(2)(undefined)(3)(4);
+      
+      assert.deepEqual(scan(), [1, 2, undefined, 3, 4]);
+    });
   });
   
   describe('merge', function() {
@@ -455,6 +465,22 @@ describe('stream', function() {
       flyd.map(function(v) { result.push(v); }, s1and2);
       s1(12)(2); s2(4)(44); s1(1); s2(12)(2);
       assert.deepEqual(result, [12, 2, 4, 44, 1, 12, 2]);
+    });
+    it('should pass defined undefined along', function(){
+      var s1 = stream();
+      var s2 = stream(undefined);
+      var merged = flyd.merge(s1, s2);
+      
+      assert.equal(merged(), undefined);
+      
+      s1(25);
+      assert.equal(merged(), 25);
+      
+      s1(undefined);
+      assert.equal(merged(), undefined);
+      
+      s2(15);
+      assert.equal(merged(), 15);
     });
     it('ends only when both merged streams have ended', function() {
       var result = [];


### PR DESCRIPTION
Currently, in a dependent stream you have to capture the parent stream in a closure:
```
var a = flyd.stream(0);
var b = a.map((x) => x * 2);
var dep = flyd.stream([a, b], (self, changed) => {
  // Required to defined b outside and capture it
  return a() + b();
});
```

Because it requires a closure, you have to write your combine functions in a non reusable fashion.

I'm proposing the following nonbreaking change to address this:
```
var sumCombine = (self, changed, x, y) => x() + y();

// ELSEWHERE
var a = flyd.stream([depA, depB], sumCombine);
var b = flyd.stream([depC, depD], sumCombine);
var allTheSums = flyd.stream([a, b], sumCombine);
```

This can be taken a step further for better, reusable join functions. However, it requires a breaking change:
```
flyd.stream([a, b, ...], (a, b, ..., self, changed) => {
});
```

Which allows reusable joins, nice partial functions, just all good things functional wants:
```
// Assuming functions are curried by default
var sumStreams = (a, b, c) => a() + b() + c();
var addFive = sum(flyd.stream(5));

var nice = flyd.stream([someDepA, someDepB], addFive);
```

Super sexy combines. Full access to `self` and `changed` if needed (but because return maps nicely, it's no worries)