### PR TITLE
flyd.stream accepts promise, but directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,11 @@ fulfilled value of the promise will be sent down the stream.
 
 ```javascript
 var urls = flyd.stream('/something.json');
-var responses = flyd.stream(function() {
-  return requestPromise(urls());
-});
-flyd.combine(function(responses) {
+var responses = flyd.stream(requestPromise(urls()));
+flyd.on(function(responses) {
   console.log('Received response!');
   console.log(responses());
-}, [responses]);
+}, responses);
 ```
 
 ### Mapping over a stream


### PR DESCRIPTION
If function passed to `flyd.stream` it's treated as value. But `flyd.stream` can capture promise if passed directly.