### PR TITLE
Add documentation to functions in main file.

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,0 +1,376 @@
+## `flyd`
+
+
+
+
+
+
+
+
+## `flyd.combine`
+
+Create a new dependent stream
+
+__Signature__: `(...Stream * -> Stream b -> b) -> [Stream *] -> Stream b`
+
+### Parameters
+
+* `fn` **`Function`** the function used to combine the streams
+* `dependencies` **`Array<stream>`** the streams that this one depends on
+
+
+### Examples
+
+```js
+var n1 = flyd.stream(0);
+var n2 = flyd.stream(0);
+var max = flyd.combine(function(n1, n2, self, changed) {
+  return n1() > n2() ? n1() : n2();
+}, [n1, n2]);
+```
+
+Returns `stream` the dependent stream
+
+
+## `flyd.curryN`
+
+Returns `fn` curried to `n`. Use this function to curry functions exposed by
+modules for Flyd.
+
+### Parameters
+
+* `arity` **`Integer`** the function arity
+* `fn` **`Function`** the function to curry
+
+
+### Examples
+
+```js
+function add(x, y) { return x + y; };
+var a = flyd.curryN(2, add);
+a(2)(4) // => 6
+```
+
+Returns `Function` the curried function
+
+
+## `flyd.endsOn`
+
+Changes which `endsStream` should trigger the ending of `s`.
+
+__Signature__: `Stream a -> Stream b -> Stream b`
+
+### Parameters
+
+* `endStream` **`stream`** the stream to trigger the ending
+* `stream` **`stream`** the stream to be ended by the endStream
+* `the` **`stream`** stream modified to be ended by endStream
+
+
+### Examples
+
+```js
+var n = flyd.stream(1);
+var killer = flyd.stream();
+// `double` ends when `n` ends or when `killer` emits any value
+var double = flyd.endsOn(flyd.merge(n.end, killer), flyd.combine(function(n) {
+  return 2 * n();
+}, [n]);
+```
+
+
+
+## `flyd.immediate`
+
+Invokes the body (the function to calculate the value) of a dependent stream
+
+By default the body of a dependent stream is only called when all the streams
+upon which it depends has a value. `immediate` can circumvent this behaviour.
+It immediately invokes the body of a dependent stream.
+
+__Signature__: `Stream a -> Stream a`
+
+### Parameters
+
+* `stream` **`stream`** the dependent stream
+
+
+### Examples
+
+```js
+var s = flyd.stream();
+var hasItems = flyd.immediate(flyd.combine(function(s) {
+  return s() !== undefined && s().length > 0;
+}, [s]);
+console.log(hasItems()); // logs `false`. Had `immediate` not been
+                         // used `hasItems()` would've returned `undefined`
+s([1]);
+console.log(hasItems()); // logs `true`.
+s([]);
+console.log(hasItems()); // logs `false`.
+```
+
+Returns `stream` the same stream
+
+
+## `flyd.isStream`
+
+Returns `true` if the supplied argument is a Flyd stream and `false` otherwise.
+
+__Signature__: `* -> Boolean`
+
+### Parameters
+
+* `value` **`Any`** the value to test
+
+
+### Examples
+
+```js
+var s = flyd.stream(1);
+var n = 1;
+flyd.isStream(s); //=> true
+flyd.isStream(n); //=> false
+```
+
+Returns `Boolean` `true` if is a Flyd streamn, `false` otherwise
+
+
+## `flyd.map`
+
+Map a stream
+
+Returns a new stream consisting of every value from `s` passed through
+`fn`. I.e. `map` creates a new stream that listens to `s` and
+applies `fn` to every new value.
+__Signature__: `(a -> result) -> Stream a -> Stream result`
+
+### Parameters
+
+* `fn` **`Function`** the function that produces the elements of the new stream
+* `stream` **`stream`** the stream to map
+
+
+### Examples
+
+```js
+var numbers = flyd.stream(0);
+var squaredNumbers = flyd.map(function(n) { return n*n; }, numbers);
+```
+
+Returns `stream` a new stream with the mapped values
+
+
+## `flyd.merge`
+
+Creates a new stream down which all values from both `stream1` and `stream2`
+will be sent.
+
+__Signature__: `Stream a -> Stream a -> Stream a`
+
+### Parameters
+
+* `source1` **`stream`** one stream to be merged
+* `source2` **`stream`** the other stream to be merged
+
+
+### Examples
+
+```js
+var btn1Clicks = flyd.stream();
+button1Elm.addEventListener(btn1Clicks);
+var btn2Clicks = flyd.stream();
+button2Elm.addEventListener(btn2Clicks);
+var allClicks = flyd.merge(btn1Clicks, btn2Clicks);
+```
+
+Returns `stream` a stream with the values from both sources
+
+
+## `flyd.on`
+
+Listen to stream events
+
+Similair to `map` except that the returned stream is empty. Use `on` for doing
+side effects in reaction to stream changes. Use the returned stream only if you
+need to manually end it.
+
+__Signature__: `(a -> result) -> Stream a -> Stream undefined`
+
+### Parameters
+
+* `cb` **`Function`** the callback
+* `stream` **`stream`** the stream
+
+
+
+Returns `stream` an empty stream (can be ended)
+
+
+## `flyd.scan`
+
+Creates a new stream with the results of calling the function on every incoming
+stream with and accumulator and the incoming value.
+
+__Signature__: `(a -> b -> a) -> a -> Stream b -> Stream a`
+
+### Parameters
+
+* `fn` **`Function`** the function to call
+* `val` **`Any`** the initial value of the accumulator
+* `stream` **`stream`** the stream source
+
+
+### Examples
+
+```js
+var numbers = flyd.stream();
+var sum = flyd.scan(function(sum, n) { return sum+n; }, 0, numbers);
+numbers(2)(3)(5);
+sum(); // 10
+```
+
+Returns `stream` the new stream
+
+
+## `flyd.stream`
+
+Creates a new stream
+
+__Signature__: `a -> Stream a`
+
+### Parameters
+
+* `initialValue` **`Any`** (Optional) the initial value of the stream
+
+
+### Examples
+
+```js
+var n = flyd.stream(1); // Stream with initial value `1`
+var s = flyd.stream(); // Stream with no initial value
+```
+
+Returns `stream` the stream
+
+
+## `flyd.transduce`
+
+Creates a new stream resulting from applying `transducer` to `stream`.
+
+__Signature__: `Transducer -> Stream a -> Stream b`
+
+### Parameters
+
+* `xform` **`Transducer`** the transducer transformation
+* `source` **`stream`** the stream source
+
+
+### Examples
+
+```js
+var t = require('transducers.js');
+
+var results = [];
+var s1 = flyd.stream();
+var tx = t.compose(t.map(function(x) { return x * 2; }), t.dedupe());
+var s2 = flyd.transduce(tx, s1);
+flyd.combine(function(s2) { results.push(s2()); }, [s2]);
+s1(1)(1)(2)(3)(3)(3)(4);
+results; // => [2, 4, 6, 8]
+```
+
+Returns `stream` the new stream
+
+
+## `stream.ap`
+
+Returns a new stream which is the result of applying the
+functions from `this` stream to the values in `stream` parameter.
+
+`this` stream must be a stream of functions.
+
+_Note:_ This function is included in order to support the fantasy land
+specification.
+
+__Signature__: Called bound to `Stream (a -> b)`: `a -> Stream b`
+
+### Parameters
+
+* `stream` **`stream`** the values stream
+
+
+### Examples
+
+```js
+var add = flyd.curryN(2, function(x, y) { return x + y; });
+var numbers1 = flyd.stream();
+var numbers2 = flyd.stream();
+var addToNumbers1 = flyd.map(add, numbers1);
+var added = addToNumbers1.ap(numbers2);
+```
+
+Returns `stream` a new stram with the functions applied to values
+
+
+## `stream.end`
+
+
+
+
+
+
+
+
+## `stream.map`
+
+Returns a new stream identical to the original except every
+value will be passed through `f`.
+
+_Note:_ This function is included in order to support the fantasy land
+specification.
+
+__Signature__: Called bound to `Stream a`: `(a -> b) -> Stream b`
+
+### Parameters
+
+* `function` **`Function`** the function to apply
+
+
+### Examples
+
+```js
+var numbers = flyd.stream(0);
+var squaredNumbers = numbers.map(function(n) { return n*n; });
+```
+
+Returns `stream` a new stream with the values mapped
+
+
+## `stream.of`
+
+
+
+### Parameters
+
+* `value` **`Any`** the initial value
+
+
+### Examples
+
+```js
+var n = flyd.stream(1);
+var m = n.of(1);
+```
+
+Returns `stream` the new stream
+
+
+## `stream.toString`
+
+Get a human readable view of a stream
+
+
+
+
+Returns `String` the stream string representation

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,243 +1,39 @@
-var curryN = require('ramda/src/curryN');
-
 'use strict';
 
+var curryN = require('ramda/src/curryN');
+
+// Utility
 function isFunction(obj) {
   return !!(obj && obj.constructor && obj.call && obj.apply);
 }
+function trueFn() { return true; }
 
 // Globals
 var toUpdate = [];
 var inStream;
-
-// Library functions use self callback to accept (null, undefined) update triggers.
-function map(f, s) {
-  return combine(function(s, self) { self(f(s.val)); }, [s]);
-}
-
-function on(f, s) {
-  return combine(function(s) { f(s.val); }, [s]);
-}
-
-function boundMap(f) { return map(f, this); }
-
-var scan = curryN(3, function(f, acc, s) {
-  var ns = combine(function(s, self) {
-    self(acc = f(acc, s.val));
-  }, [s]);
-  if (!ns.hasVal) ns(acc);
-  return ns;
-});
-
-var merge = curryN(2, function(s1, s2) {
-  var s = immediate(combine(function(s1, s2, self, changed) {
-    if (changed[0]) {
-      self(changed[0]());
-    } else if (s1.hasVal) {
-      self(s1.val);
-    } else if (s2.hasVal) {
-      self(s2.val);
-    }
-  }, [s1, s2]));
-  endsOn(combine(function() {
-    return true;
-  }, [s1.end, s2.end]), s);
-  return s;
-});
-
-function ap(s2) {
-  var s1 = this;
-  return combine(function(s1, s2, self) { self(s1.val(s2.val)); }, [s1, s2]);
-}
-
-function initialDepsNotMet(stream) {
-  stream.depsMet = stream.deps.every(function(s) {
-    return s.hasVal;
-  });
-  return !stream.depsMet;
-}
-
-function updateStream(s) {
-  if ((s.depsMet !== true && initialDepsNotMet(s)) ||
-      (s.end !== undefined && s.end.val === true)) return;
-  if (inStream !== undefined) {
-    toUpdate.push(s);
-    return;
-  }
-  inStream = s;
-  if (s.depsChanged) s.fnArgs[s.fnArgs.length - 1] = s.depsChanged;
-  var returnVal = s.fn.apply(s.fn, s.fnArgs);
-  if (returnVal !== undefined) {
-    s(returnVal);
-  }
-  inStream = undefined;
-  if (s.depsChanged !== undefined) s.depsChanged = [];
-  s.shouldUpdate = false;
-  if (flushing === false) flushUpdate();
-}
-
 var order = [];
 var orderNextIdx = -1;
-
-function findDeps(s) {
-  var i
-  var listeners = s.listeners;
-  if (s.queued === false) {
-    s.queued = true;
-    for (i = 0; i < listeners.length; ++i) {
-      findDeps(listeners[i]);
-    }
-    order[++orderNextIdx] = s;
-  }
-}
-
-function updateDeps(s) {
-  var i, o, list
-  var listeners = s.listeners;
-  for (i = 0; i < listeners.length; ++i) {
-    list = listeners[i];
-    if (list.end === s) {
-      endStream(list);
-    } else {
-      if (list.depsChanged !== undefined) list.depsChanged.push(s);
-      list.shouldUpdate = true;
-      findDeps(list);
-    }
-  }
-  for (; orderNextIdx >= 0; --orderNextIdx) {
-    o = order[orderNextIdx];
-    if (o.shouldUpdate === true) updateStream(o);
-    o.queued = false;
-  }
-}
-
 var flushing = false;
 
-function flushUpdate() {
-  flushing = true;
-  while (toUpdate.length > 0) {
-    var s = toUpdate.shift();
-    if (s.vals.length > 0) s.val = s.vals.shift();
-    updateDeps(s);
-  }
-  flushing = false;
-}
+/** @namespace */
+var flyd = {}
 
-function isStream(stream) {
-  return isFunction(stream) && 'hasVal' in stream;
-}
+// /////////////////////////// API ///////////////////////////////// //
 
-function streamToString() {
-  return 'stream(' + this.val + ')';
-}
-
-function updateStreamValue(s, n) {
-  if (n !== undefined && n !== null && isFunction(n.then)) {
-    n.then(s);
-    return;
-  }
-  s.val = n;
-  s.hasVal = true;
-  if (inStream === undefined) {
-    flushing = true;
-    updateDeps(s);
-    if (toUpdate.length > 0) flushUpdate(); else flushing = false;
-  } else if (inStream === s) {
-    markListeners(s, s.listeners);
-  } else {
-    s.vals.push(n);
-    toUpdate.push(s);
-  }
-}
-
-function markListeners(s, lists) {
-  var i, list;
-  for (i = 0; i < lists.length; ++i) {
-    list = lists[i];
-    if (list.end !== s) {
-      if (list.depsChanged !== undefined) {
-        list.depsChanged.push(s);
-      }
-      list.shouldUpdate = true;
-    } else {
-      endStream(list);
-    }
-  }
-}
-
-function createStream() {
-  function s(n) {
-    return arguments.length > 0 ? (updateStreamValue(s, n), s)
-                                : s.val;
-  }
-  s.hasVal = false;
-  s.val = undefined;
-  s.vals = [];
-  s.listeners = [];
-  s.queued = false;
-  s.end = undefined;
-
-  s.map = boundMap;
-  s.ap = ap;
-  s.of = stream;
-  s.toString = streamToString;
-
-  return s;
-}
-
-function addListeners(deps, s) {
-  for (var i = 0; i < deps.length; ++i) {
-    deps[i].listeners.push(s);
-  }
-}
-
-function createDependentStream(deps, fn) {
-  var s = createStream();
-  s.fn = fn;
-  s.deps = deps;
-  s.depsMet = false;
-  s.depsChanged = deps.length > 0 ? [] : undefined;
-  s.shouldUpdate = false;
-  addListeners(deps, s);
-  return s;
-}
-
-function immediate(s) {
-  if (s.depsMet === false) {
-    s.depsMet = true;
-    updateStream(s);
-  }
-  return s;
-}
-
-function removeListener(s, listeners) {
-  var idx = listeners.indexOf(s);
-  listeners[idx] = listeners[listeners.length - 1];
-  listeners.length--;
-}
-
-function detachDeps(s) {
-  for (var i = 0; i < s.deps.length; ++i) {
-    removeListener(s, s.deps[i].listeners);
-  }
-  s.deps.length = 0;
-}
-
-function endStream(s) {
-  if (s.deps !== undefined) detachDeps(s);
-  if (s.end !== undefined) detachDeps(s.end);
-}
-
-function endsOn(endS, s) {
-  detachDeps(s.end);
-  endS.listeners.push(s.end);
-  s.end.deps.push(endS);
-  return s;
-}
-
-function trueFn() { return true; }
-
-function stream(initialValue) {
+/**
+ * Creates a new stream
+ *
+ * __Signature__: `a -> Stream a`
+ *
+ * @name flyd.stream
+ * @param {*} initialValue - (Optional) the initial value of the stream
+ * @return {stream} the stream
+ *
+ * @example
+ * var n = flyd.stream(1); // Stream with initial value `1`
+ * var s = flyd.stream(); // Stream with no initial value
+ */
+flyd.stream = function(initialValue) {
   var endStream = createDependentStream([], trueFn);
   var s = createStream();
   s.end = endStream;
@@ -247,6 +43,24 @@ function stream(initialValue) {
   return s;
 }
 
+/**
+ * Create a new dependent stream
+ *
+ * __Signature__: `(...Stream * -> Stream b -> b) -> [Stream *] -> Stream b`
+ *
+ * @name flyd.combine
+ * @param {Function} fn - the function used to combine the streams
+ * @param {Array<stream>} dependencies - the streams that this one depends on
+ * @return {stream} the dependent stream
+ *
+ * @example
+ * var n1 = flyd.stream(0);
+ * var n2 = flyd.stream(0);
+ * var max = flyd.combine(function(n1, n2, self, changed) {
+ *   return n1() > n2() ? n1() : n2();
+ * }, [n1, n2]);
+ */
+flyd.combine = curryN(2, combine);
 function combine(fn, streams) {
   var i, s, deps, depEndStreams;
   var endStream = createDependentStream([], trueFn);
@@ -268,7 +82,205 @@ function combine(fn, streams) {
   return s;
 }
 
-var transduce = curryN(2, function(xform, source) {
+/**
+ * Returns `true` if the supplied argument is a Flyd stream and `false` otherwise.
+ *
+ * __Signature__: `* -> Boolean`
+ *
+ * @name flyd.isStream
+ * @param {*} value - the value to test
+ * @return {Boolean} `true` if is a Flyd streamn, `false` otherwise
+ *
+ * @example
+ * var s = flyd.stream(1);
+ * var n = 1;
+ * flyd.isStream(s); //=> true
+ * flyd.isStream(n); //=> false
+ */
+flyd.isStream = function(stream) {
+  return isFunction(stream) && 'hasVal' in stream;
+}
+
+/**
+ * Invokes the body (the function to calculate the value) of a dependent stream
+ *
+ * By default the body of a dependent stream is only called when all the streams
+ * upon which it depends has a value. `immediate` can circumvent this behaviour.
+ * It immediately invokes the body of a dependent stream.
+ *
+ * __Signature__: `Stream a -> Stream a`
+ *
+ * @name flyd.immediate
+ * @param {stream} stream - the dependent stream
+ * @return {stream} the same stream
+ *
+ * @example
+ * var s = flyd.stream();
+ * var hasItems = flyd.immediate(flyd.combine(function(s) {
+ *   return s() !== undefined && s().length > 0;
+ * }, [s]);
+ * console.log(hasItems()); // logs `false`. Had `immediate` not been
+ *                          // used `hasItems()` would've returned `undefined`
+ * s([1]);
+ * console.log(hasItems()); // logs `true`.
+ * s([]);
+ * console.log(hasItems()); // logs `false`.
+ */
+flyd.immediate = function(s) {
+  if (s.depsMet === false) {
+    s.depsMet = true;
+    updateStream(s);
+  }
+  return s;
+}
+
+/**
+ * Changes which `endsStream` should trigger the ending of `s`.
+ *
+ * __Signature__: `Stream a -> Stream b -> Stream b`
+ *
+ * @name flyd.endsOn
+ * @param {stream} endStream - the stream to trigger the ending
+ * @param {stream} stream - the stream to be ended by the endStream
+ * @param {stream} the stream modified to be ended by endStream
+ *
+ * @example
+ * var n = flyd.stream(1);
+ * var killer = flyd.stream();
+ * // `double` ends when `n` ends or when `killer` emits any value
+ * var double = flyd.endsOn(flyd.merge(n.end, killer), flyd.combine(function(n) {
+ *   return 2 * n();
+ * }, [n]);
+*/
+flyd.endsOn = function(endS, s) {
+  detachDeps(s.end);
+  endS.listeners.push(s.end);
+  s.end.deps.push(endS);
+  return s;
+}
+
+/**
+ * Map a stream
+ *
+ * Returns a new stream consisting of every value from `s` passed through
+ * `fn`. I.e. `map` creates a new stream that listens to `s` and
+ * applies `fn` to every new value.
+ * __Signature__: `(a -> result) -> Stream a -> Stream result`
+ *
+ * @name flyd.map
+ * @param {Function} fn - the function that produces the elements of the new stream
+ * @param {stream} stream - the stream to map
+ * @return {stream} a new stream with the mapped values
+ *
+ * @example
+ * var numbers = flyd.stream(0);
+ * var squaredNumbers = flyd.map(function(n) { return n*n; }, numbers);
+ */
+// Library functions use self callback to accept (null, undefined) update triggers.
+flyd.map = curryN(2, function(f, s) {
+  return combine(function(s, self) { self(f(s.val)); }, [s]);
+})
+
+/**
+ * Listen to stream events
+ *
+ * Similair to `map` except that the returned stream is empty. Use `on` for doing
+ * side effects in reaction to stream changes. Use the returned stream only if you
+ * need to manually end it.
+ *
+ * __Signature__: `(a -> result) -> Stream a -> Stream undefined`
+ *
+ * @name flyd.on
+ * @param {Function} cb - the callback
+ * @param {stream} stream - the stream
+ * @return {stream} an empty stream (can be ended)
+ */
+flyd.on = curryN(2, function(f, s) {
+  return combine(function(s) { f(s.val); }, [s]);
+})
+
+/**
+ * Creates a new stream with the results of calling the function on every incoming
+ * stream with and accumulator and the incoming value.
+ *
+ * __Signature__: `(a -> b -> a) -> a -> Stream b -> Stream a`
+ *
+ * @name flyd.scan
+ * @param {Function} fn - the function to call
+ * @param {*} val - the initial value of the accumulator
+ * @param {stream} stream - the stream source
+ * @return {stream} the new stream
+ *
+ * @example
+ * var numbers = flyd.stream();
+ * var sum = flyd.scan(function(sum, n) { return sum+n; }, 0, numbers);
+ * numbers(2)(3)(5);
+ * sum(); // 10
+ */
+flyd.scan = curryN(3, function(f, acc, s) {
+  var ns = combine(function(s, self) {
+    self(acc = f(acc, s.val));
+  }, [s]);
+  if (!ns.hasVal) ns(acc);
+  return ns;
+});
+
+/**
+ * Creates a new stream down which all values from both `stream1` and `stream2`
+ * will be sent.
+ *
+ * __Signature__: `Stream a -> Stream a -> Stream a`
+ *
+ * @name flyd.merge
+ * @param {stream} source1 - one stream to be merged
+ * @param {stream} source2 - the other stream to be merged
+ * @return {stream} a stream with the values from both sources
+ *
+ * @example
+ * var btn1Clicks = flyd.stream();
+ * button1Elm.addEventListener(btn1Clicks);
+ * var btn2Clicks = flyd.stream();
+ * button2Elm.addEventListener(btn2Clicks);
+ * var allClicks = flyd.merge(btn1Clicks, btn2Clicks);
+ */
+flyd.merge = curryN(2, function(s1, s2) {
+  var s = flyd.immediate(combine(function(s1, s2, self, changed) {
+    if (changed[0]) {
+      self(changed[0]());
+    } else if (s1.hasVal) {
+      self(s1.val);
+    } else if (s2.hasVal) {
+      self(s2.val);
+    }
+  }, [s1, s2]));
+  flyd.endsOn(combine(function() {
+    return true;
+  }, [s1.end, s2.end]), s);
+  return s;
+});
+
+/**
+ * Creates a new stream resulting from applying `transducer` to `stream`.
+ *
+ * __Signature__: `Transducer -> Stream a -> Stream b`
+ *
+ * @name flyd.transduce
+ * @param {Transducer} xform - the transducer transformation
+ * @param {stream} source - the stream source
+ * @return {stream} the new stream
+ *
+ * @example
+ * var t = require('transducers.js');
+ *
+ * var results = [];
+ * var s1 = flyd.stream();
+ * var tx = t.compose(t.map(function(x) { return x * 2; }), t.dedupe());
+ * var s2 = flyd.transduce(tx, s1);
+ * flyd.combine(function(s2) { results.push(s2()); }, [s2]);
+ * s1(1)(1)(2)(3)(3)(3)(4);
+ * results; // => [2, 4, 6, 8]
+ */
+flyd.transduce = curryN(2, function(xform, source) {
   xform = xform(new StreamTransformer());
   return combine(function(source, self) {
     var res = xform['@@transducer/step'](undefined, source.val);
@@ -281,21 +293,334 @@ var transduce = curryN(2, function(xform, source) {
   }, [source]);
 });
 
+/**
+ * Returns `fn` curried to `n`. Use this function to curry functions exposed by
+ * modules for Flyd.
+ *
+ * @name flyd.curryN
+ * @function
+ * @param {Integer} arity - the function arity
+ * @param {Function} fn - the function to curry
+ * @return {Function} the curried function
+ *
+ * @example
+ * function add(x, y) { return x + y; };
+ * var a = flyd.curryN(2, add);
+ * a(2)(4) // => 6
+ */
+flyd.curryN = curryN
+
+/**
+ * Returns a new stream identical to the original except every
+ * value will be passed through `f`.
+ *
+ * _Note:_ This function is included in order to support the fantasy land
+ * specification.
+ *
+ * __Signature__: Called bound to `Stream a`: `(a -> b) -> Stream b`
+ *
+ * @name stream.map
+ * @param {Function} function - the function to apply
+ * @return {stream} a new stream with the values mapped
+ *
+ * @example
+ * var numbers = flyd.stream(0);
+ * var squaredNumbers = numbers.map(function(n) { return n*n; });
+ */
+function boundMap(f) { return flyd.map(f, this); }
+
+/**
+ * Returns a new stream which is the result of applying the
+ * functions from `this` stream to the values in `stream` parameter.
+ *
+ * `this` stream must be a stream of functions.
+ *
+ * _Note:_ This function is included in order to support the fantasy land
+ * specification.
+ *
+ * __Signature__: Called bound to `Stream (a -> b)`: `a -> Stream b`
+ *
+ * @name stream.ap
+ * @param {stream} stream - the values stream
+ * @return {stream} a new stram with the functions applied to values
+ *
+ * @example
+ * var add = flyd.curryN(2, function(x, y) { return x + y; });
+ * var numbers1 = flyd.stream();
+ * var numbers2 = flyd.stream();
+ * var addToNumbers1 = flyd.map(add, numbers1);
+ * var added = addToNumbers1.ap(numbers2);
+ */
+function ap(s2) {
+  var s1 = this;
+  return combine(function(s1, s2, self) { self(s1.val(s2.val)); }, [s1, s2]);
+}
+
+/**
+ * Get a human readable view of a stream
+ * @name stream.toString
+ * @return {String} the stream string representation
+ */
+function streamToString() {
+  return 'stream(' + this.val + ')';
+}
+
+/**
+ * @name stream.end
+ * @memberof stream
+ * A stream that emits `true` when the stream ends. If `true` is pushed down the
+ * stream the parent stream ends.
+ */
+
+/**
+ * @name stream.of
+ * @function
+ * @memberof stream
+ * Returns a new stream with `value` as its initial value. It is identical to
+ * calling `flyd.stream` with one argument.
+ *
+ * __Signature__: Called bound to `Stream (a)`: `b -> Stream b`
+ *
+ * @param {*} value - the initial value
+ * @return {stream} the new stream
+ *
+ * @example
+ * var n = flyd.stream(1);
+ * var m = n.of(1);
+ */
+
+// /////////////////////////// PRIVATE ///////////////////////////////// //
+/**
+ * @private
+ * Create a stream with no dependencies and no value
+ * @return {Function} a flyd stream
+ */
+function createStream() {
+  function s(n) {
+    if (arguments.length === 0) return s.val
+    updateStreamValue(s, n)
+    return s
+  }
+  s.hasVal = false;
+  s.val = undefined;
+  s.vals = [];
+  s.listeners = [];
+  s.queued = false;
+  s.end = undefined;
+  s.map = boundMap;
+  s.ap = ap;
+  s.of = flyd.stream;
+  s.toString = streamToString;
+  return s;
+}
+
+/**
+ * @private
+ * Create a dependent stream
+ * @param {Array<stream>} dependencies - an array of the streams
+ * @param {Function} fn - the function used to calculate the new stream value
+ * from the dependencies
+ * @return {stream} the created stream
+ */
+function createDependentStream(deps, fn) {
+  var s = createStream();
+  s.fn = fn;
+  s.deps = deps;
+  s.depsMet = false;
+  s.depsChanged = deps.length > 0 ? [] : undefined;
+  s.shouldUpdate = false;
+  addListeners(deps, s);
+  return s;
+}
+
+/**
+ * @private
+ * Check if all the dependencies have values
+ * @param {stream} stream - the stream to check depencencies from
+ * @return {Boolean} `true` if all dependencies have vales, `false` otherwise
+ */
+function initialDepsNotMet(stream) {
+  stream.depsMet = stream.deps.every(function(s) {
+    return s.hasVal;
+  });
+  return !stream.depsMet;
+}
+
+/**
+ * @private
+ * Update a dependent stream using its dependencies in an atomic way
+ * @param {stream} stream - the stream to update
+ */
+function updateStream(s) {
+  if ((s.depsMet !== true && initialDepsNotMet(s)) ||
+      (s.end !== undefined && s.end.val === true)) return;
+  if (inStream !== undefined) {
+    toUpdate.push(s);
+    return;
+  }
+  inStream = s;
+  if (s.depsChanged) s.fnArgs[s.fnArgs.length - 1] = s.depsChanged;
+  var returnVal = s.fn.apply(s.fn, s.fnArgs);
+  if (returnVal !== undefined) {
+    s(returnVal);
+  }
+  inStream = undefined;
+  if (s.depsChanged !== undefined) s.depsChanged = [];
+  s.shouldUpdate = false;
+  if (flushing === false) flushUpdate();
+}
+
+/**
+ * @private
+ * Update the dependencies of a stream
+ * @param {stream} stream
+ */
+function updateDeps(s) {
+  var i, o, list
+  var listeners = s.listeners;
+  for (i = 0; i < listeners.length; ++i) {
+    list = listeners[i];
+    if (list.end === s) {
+      endStream(list);
+    } else {
+      if (list.depsChanged !== undefined) list.depsChanged.push(s);
+      list.shouldUpdate = true;
+      findDeps(list);
+    }
+  }
+  for (; orderNextIdx >= 0; --orderNextIdx) {
+    o = order[orderNextIdx];
+    if (o.shouldUpdate === true) updateStream(o);
+    o.queued = false;
+  }
+}
+
+/**
+ * @private
+ * Add stream dependencies to the global `order` queue.
+ * @param {stream} stream
+ * @see updateDeps
+ */
+function findDeps(s) {
+  var i
+  var listeners = s.listeners;
+  if (s.queued === false) {
+    s.queued = true;
+    for (i = 0; i < listeners.length; ++i) {
+      findDeps(listeners[i]);
+    }
+    order[++orderNextIdx] = s;
+  }
+}
+
+/**
+ * @private
+ */
+function flushUpdate() {
+  flushing = true;
+  while (toUpdate.length > 0) {
+    var s = toUpdate.shift();
+    if (s.vals.length > 0) s.val = s.vals.shift();
+    updateDeps(s);
+  }
+  flushing = false;
+}
+
+/**
+ * @private
+ * Push down a value into a stream
+ * @param {stream} stream
+ * @param {*} value
+ */
+function updateStreamValue(s, n) {
+  if (n !== undefined && n !== null && isFunction(n.then)) {
+    n.then(s);
+    return;
+  }
+  s.val = n;
+  s.hasVal = true;
+  if (inStream === undefined) {
+    flushing = true;
+    updateDeps(s);
+    if (toUpdate.length > 0) flushUpdate(); else flushing = false;
+  } else if (inStream === s) {
+    markListeners(s, s.listeners);
+  } else {
+    s.vals.push(n);
+    toUpdate.push(s);
+  }
+}
+
+/**
+ * @private
+ */
+function markListeners(s, lists) {
+  var i, list;
+  for (i = 0; i < lists.length; ++i) {
+    list = lists[i];
+    if (list.end !== s) {
+      if (list.depsChanged !== undefined) {
+        list.depsChanged.push(s);
+      }
+      list.shouldUpdate = true;
+    } else {
+      endStream(list);
+    }
+  }
+}
+
+/**
+ * @private
+ * Add dependencies to a stream
+ * @param {Array<stream>} dependencies
+ * @param {stream} stream
+ */
+function addListeners(deps, s) {
+  for (var i = 0; i < deps.length; ++i) {
+    deps[i].listeners.push(s);
+  }
+}
+
+/**
+ * @private
+ * Removes an stream from a dependency array
+ * @param {stream} stream
+ * @param {Array<stream>} dependencies
+ */
+function removeListener(s, listeners) {
+  var idx = listeners.indexOf(s);
+  listeners[idx] = listeners[listeners.length - 1];
+  listeners.length--;
+}
+
+/**
+ * @private
+ * Detach a stream from its dependencies
+ * @param {stream} stream
+ */
+function detachDeps(s) {
+  for (var i = 0; i < s.deps.length; ++i) {
+    removeListener(s, s.deps[i].listeners);
+  }
+  s.deps.length = 0;
+}
+
+/**
+ * @private
+ * Ends a stream
+ */
+function endStream(s) {
+  if (s.deps !== undefined) detachDeps(s);
+  if (s.end !== undefined) detachDeps(s.end);
+}
+
+/**
+ * @private
+ * transducer stream transformer
+ */
 function StreamTransformer() { }
 StreamTransformer.prototype['@@transducer/init'] = function() { };
 StreamTransformer.prototype['@@transducer/result'] = function() { };
 StreamTransformer.prototype['@@transducer/step'] = function(s, v) { return v; };
 
-module.exports = {
-  stream: stream,
-  combine: curryN(2, combine),
-  isStream: isStream,
-  transduce: transduce,
-  merge: merge,
-  scan: scan,
-  endsOn: endsOn,
-  map: curryN(2, map),
-  on: curryN(2, on),
-  curryN: curryN,
-  immediate: immediate
-};
+module.exports = flyd;

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "scripts": {
     "test": "mocha",
     "test-all": "eslint lib/ test/ module/ && mocha -R dot test/*.js module/**/test/*.js",
+    "docs": "documentation -f md lib/index.js > API.md",
     "perf": "./perf/run-benchmarks",
     "post-to-coveralls-io": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "build": "browserify -s flyd lib/index.js > flyd.js"


### PR DESCRIPTION
The purpose of this change is double: 1) make the code easy to understand and follow, and 2) allow to generate API documentation automatically

Changes to lib/index.js:

- Copy README documentation to jsdoc comments
- Add description to all private functions
- Group all global variables
- Group all flyd.* functions
- Move all private functions to bottom of the file
- Create a flyd object and populate with functions instead of a module.exports object

Changes to project:

- Add `docs` script to generate API.md file with documentation (it assumes documentation is installed globally in the system: `npm i -g documentation`)
- Add API.md with the generated documentation