### PR TITLE
The `test` script now runs all the tests (fixes #89)

### DIFF
--- a/README.md
+++ b/README.md
@@ -697,3 +697,21 @@ stream.
 
 Flyd works in all ECMAScript 5 environments. It works in older environments
 with polyfills for `Array.prototype.filter` and `Array.prototype.map`.
+
+### Run tests, generate documentation
+
+To run the test, clone this repository and:
+
+```bash
+npm install
+npm test
+```
+
+The `npm test` command run three tests: a eslint js style checker test, the test of the core library and the test of the modules. If you wan't to run only the test of the library `npm run test`.
+
+The API.md file is generated using `npm run docs` (it assumes it has documentation installed globally: `npm i -g documentation`)
+
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -12,17 +12,18 @@
   },
   "devDependencies": {
     "benchmark": "^1.0.0",
-    "browserify": "^10.2.4",
     "bluebird": "^2.9.13",
+    "browserify": "^10.2.4",
     "coveralls": "^2.11.2",
+    "eslint": "^1.10.3",
     "istanbul": "^0.3.15",
     "mocha": "^2.2.1",
     "mocha-lcov-reporter": "0.0.2",
     "transducers.js": "0.3.x"
   },
   "scripts": {
-    "test": "mocha",
-    "test-all": "eslint lib/ test/ module/ && mocha -R dot test/*.js module/**/test/*.js",
+    "test-lib": "mocha",
+    "test": "eslint lib/ test/ module/ && mocha -R dot test/*.js module/**/test/*.js",
     "docs": "documentation -f md lib/index.js > API.md",
     "perf": "./perf/run-benchmarks",
     "post-to-coveralls-io": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",


### PR DESCRIPTION
All the tests include (in order):
- the eslint javascript style check
- the core library unit tests
- the module library unit tests

The (old) `test` script is now called `test-lib`

Also, a little section is added to the bottom of the README explaining how to run test and generate documentation.