### PR TITLE
repeats push first value to stream without running equality check

### DIFF
--- a/module/droprepeats/index.js
+++ b/module/droprepeats/index.js
@@ -3,7 +3,7 @@ var flyd = require('../../lib');
 function dropRepeatsWith(eq, s) {
   var prev;
   return flyd.combine(function(s, self) {
-    if (!eq(s.val, prev)) {
+    if (!self.hasVal || !eq(s.val, prev)) {
       self(s.val);
       prev = s.val;
     }

--- a/module/droprepeats/test/index.js
+++ b/module/droprepeats/test/index.js
@@ -38,6 +38,20 @@ describe('dropRepeatsWith', function() {
     ]);
   });
 
+  it('always includes first value so we can safely test for equality', function() {
+    var s = stream();
+    var all = collect(dropRepeatsWith(function(a, b) {
+      return a[0] === b[0] || a[1] === b[1];
+    }, s));
+    s([1, 2]);
+    s([1, 3]);
+    s([2, 3]);
+    assert.deepEqual(all(), [
+      [1, 2],
+      [2, 3]
+    ]);
+  });
+
   it('is curried', function() {
     var s = stream();
     var equalsDropper = dropRepeatsWith(R.equals);


### PR DESCRIPTION
The first value can never be a repeat, so push it without running equality check. This is important as it means the user will not have to worry about whether the previous value will be defined (it never will be when first run!) when they supply an equality function to `dropRepeatsWith`.

Please double check "implementation" for me, I was originally going to go with a simple/hacky solution, but noticed the `hasVal` property on streams which made things even easier (but I'm not positive is correct). Is this a safe/proper use?

Thanks!