### PR TITLE
adds toJSON method to streams

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -39,6 +39,9 @@ flyd.stream = function(initialValue) {
   s.end = endStream;
   s.fnArgs = [];
   endStream.listeners.push(s);
+  s.toJSON = function() {
+    return s();
+  };
   if (arguments.length > 0) s(initialValue);
   return s;
 }

--- a/test/index.js
+++ b/test/index.js
@@ -28,6 +28,22 @@ describe('stream', function() {
     var s = stream();
     assert.equal(s, s(23));
   });
+  it('can works with JSON.stringify', function() {
+    var obj = {
+      num: stream(23),
+      str: stream('string'),
+      obj: stream({is_object: true})
+    };
+    var expected_outcome = {
+      num: 23,
+      str: 'string',
+      obj: {
+        is_object: true
+      }
+    };
+    var jsonObject = JSON.parse(JSON.stringify(obj));
+    assert.deepEqual(jsonObject, expected_outcome);
+  });
   it("let's explicit `undefined` flow down streams", function() {
     var result = [];
     var s1 = stream(undefined);


### PR DESCRIPTION
# Introduction
I use flyd streams in a lot of my model classes to allow effective data sharing between my components.

I currently use a wrapper to allow me to push changes to models over the wire without to much hassle.

```js
function stream(val){
  let s = flyd.stream(val);
  s.toJSON = ()=> s();
  return s;
}
```

This wrapper means that when I create a stream I can call `JSON.stringify(s)` and it will return the value of the stream in stead of the stream function itself.

```js
const model = {num: stream(2)};
JSON.stringify(model); // '{"num": 2}'
```

I find this immensely useful since as noted earlier I'm using flyd in a lot of my models.


## Example use case
```js
class myModel {
  constructor(data) {
    this.name = flyd.stream(data.name);
    this._id = data._id;
  }
  save(){
    return fetch('/test', {
      method: 'PUT',
      body: JSON.stringify(this)
    });
  }
}
```