### PR TITLE
Make lift update on undefined

### DIFF
--- a/module/lift/index.js
+++ b/module/lift/index.js
@@ -4,7 +4,8 @@ module.exports = function(f /* , streams */) {
   var streams = Array.prototype.slice.call(arguments, 1);
   var vals = [];
   return flyd.combine(function() {
+    var self = arguments[arguments.length - 2];
     for (var i = 0; i < streams.length; ++i) vals[i] = streams[i]();
-    return f.apply(null, vals);
+    self(f.apply(null, vals));
   }, streams);
 };

--- a/module/lift/test/index.js
+++ b/module/lift/test/index.js
@@ -29,4 +29,13 @@ describe('lift', function() {
     a(3); c(3);
     assert.equal(sum(), a() + b() + c() + d() + e());
   });
+  it('updates on undefined', function() {
+    var and = function(x, y) { return x && y; };
+    var x = stream(true);
+    var y = stream(true);
+    var s = lift(and, x, y);
+    assert.equal(s(), true);
+    x(undefined);
+    assert.equal(s(), undefined);
+  });
 });


### PR DESCRIPTION
Both flyd.map and flyd.merge functions are updating when the argument function returns undefined.

In order to be consistent, I think this should also be applied to the lift function.

I changed the behaviour and added a test.