### PR TITLE
Adding assert for creating stream without params.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -19,6 +19,7 @@ describe('stream', function() {
   });
   it('can be set', function() {
     var s = stream();
+    assert.equal(s(), undefined);
     s(23);
     assert.equal(s(), 23);
     s(3);


### PR DESCRIPTION
When creating a stream we have a check for empty params.
`if (arguments.length === 0) return s.val`

This case doesn't have an assert yet.
Since s.val is being explicit set  to undefined, would be good to have an assert to cover.