### PR TITLE
Correcting the signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,7 +450,7 @@ stream with and accumulator and the incoming value.
 
 __Signature__
 
-`(a -> b -> a) -> a -> Stream b -> Stream a`
+`((a, b) -> a) -> a -> Stream b -> Stream a`
 
 __Example__
 ```javascript


### PR DESCRIPTION
It seem the expected signature for the accumulator function from `scan` is the uncurried `(a,b)->a`. Passing the curried version as described seems to lead to different not intended results.
