### PR TITLE
Update README.md

### DIFF
--- a/module/obj/README.md
+++ b/module/obj/README.md
@@ -21,7 +21,7 @@ __Usage__
 
 ```js
 const flydObj = require('flyd/module/object')
-const obj = {x: 1, y: {z: 1}}
+const obj = {x: 1, y: {z: 2}}
 const objOfStreams = flydObj.streamProps(obj)
 
 objOfStreams.x() // 1


### PR DESCRIPTION
Fixing example for `streamProps(obj)`. Looks like there was a typo.