### PR TITLE
Fixes #160 handle streams being created in stream bodies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -578,7 +578,7 @@ function updateStreamValue(s, n) {
     if (toUpdate.length > 0) flushUpdate(); else flushing = false;
   } else if (inStream === s) {
     markListeners(s, s.listeners);
-  } else if (createdInStream.indexOf(s) !== -1 && s.end && s.end.val !== true) {
+  } else if (createdInStream.indexOf(s) !== -1) {
     // if the stream being updated was created in the body of the current stream we need to update it immediately
     var _toUpdate = toUpdate;
     var _createdInStream = createdInStream;

--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,8 @@ function trueFn() { return true; }
 // Globals
 var toUpdate = [];
 var inStream;
+// a List of streams created in the body of the current stream
+var createdInStream = [];
 var order = [];
 var orderNextIdx = -1;
 var flushing = false;
@@ -43,6 +45,9 @@ flyd.stream = function(initialValue) {
     return s();
   };
   if (arguments.length > 0) s(initialValue);
+  if (inStream !== undefined) {
+    createdInStream.push(s);
+  }
   return s;
 }
 
@@ -87,11 +92,13 @@ function combine(fn, streams) {
   // we need to give it a value instantly so as to not
   // break the expectation of the methods
   if (
-    inStream !== undefined &&
-    !(s.depsMet !== true && initialDepsNotMet(s)) &&
-    (s.end && s.end.val !== true)
+    inStream !== undefined
   ) {
-    updateCombineStream(s);
+    if (!(s.depsMet !== true && initialDepsNotMet(s)) &&
+    (s.end && s.end.val !== true)) {
+      updateCombineStream(s);
+    }
+    createdInStream.push(s);
   } else {
     updateStream(s);
   }
@@ -548,6 +555,7 @@ function flushUpdate() {
     if (s.vals.length > 0) s.val = s.vals.shift();
     updateDeps(s);
   }
+  createdInStream = [];
   flushing = false;
 }
 
@@ -570,6 +578,23 @@ function updateStreamValue(s, n) {
     if (toUpdate.length > 0) flushUpdate(); else flushing = false;
   } else if (inStream === s) {
     markListeners(s, s.listeners);
+  } else if (createdInStream.indexOf(s) !== -1) {
+    // if the stream being updated was created in the body of the current stream we need to update it immediately
+    var _toUpdate = toUpdate;
+    var _createdInStream = createdInStream;
+    var _inStream = inStream;
+    toUpdate = [];
+    createdInStream = [];
+    inStream = undefined;
+
+    flushing = true;
+    updateDeps(s);
+    if (toUpdate.length > 0) flushUpdate(); else flushing = false;
+
+    toUpdate = _toUpdate;
+    createdInStream = _createdInStream;
+    inStream = _inStream;
+
   } else {
     s.vals.push(n);
     toUpdate.push(s);

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,9 +45,6 @@ flyd.stream = function(initialValue) {
     return s();
   };
   if (arguments.length > 0) s(initialValue);
-  if (inStream !== undefined) {
-    createdInStream.push(s);
-  }
   return s;
 }
 
@@ -434,6 +431,9 @@ function createStream() {
   s.ap = ap;
   s.of = flyd.stream;
   s.toString = streamToString;
+  if (inStream !== undefined) {
+    createdInStream.push(s);
+  }
   return s;
 }
 
@@ -578,7 +578,7 @@ function updateStreamValue(s, n) {
     if (toUpdate.length > 0) flushUpdate(); else flushing = false;
   } else if (inStream === s) {
     markListeners(s, s.listeners);
-  } else if (createdInStream.indexOf(s) !== -1) {
+  } else if (createdInStream.indexOf(s) !== -1 && s.end && s.end.val !== true) {
     // if the stream being updated was created in the body of the current stream we need to update it immediately
     var _toUpdate = toUpdate;
     var _createdInStream = createdInStream;

--- a/lib/index.js
+++ b/lib/index.js
@@ -81,7 +81,20 @@ function combine(fn, streams) {
   endStream.listeners.push(s);
   addListeners(depEndStreams, endStream);
   endStream.deps = depEndStreams;
-  updateStream(s);
+
+  // if a stream is created within another stream body
+  // whose dependencies are met at the beginning
+  // we need to give it a value instantly so as to not
+  // break the expectation of the methods
+  if (
+    inStream !== undefined &&
+    !(s.depsMet !== true && initialDepsNotMet(s)) &&
+    (s.end && s.end.val !== true)
+  ) {
+    updateCombineStream(s);
+  } else {
+    updateStream(s);
+  }
   return s;
 }
 
@@ -451,6 +464,19 @@ function initialDepsNotMet(stream) {
 
 /**
  * @private
+ * Update a combine stream instantly
+ * @param {stream} stream
+ */
+function updateCombineStream(s) {
+  if (s.depsChanged) s.fnArgs[s.fnArgs.length - 1] = s.depsChanged;
+  var returnVal = s.fn.apply(s.fn, s.fnArgs);
+  if (returnVal !== undefined) {
+    s(returnVal);
+  }
+}
+
+/**
+ * @private
  * Update a dependent stream using its dependencies in an atomic way
  * @param {stream} stream - the stream to update
  */
@@ -462,11 +488,7 @@ function updateStream(s) {
     return;
   }
   inStream = s;
-  if (s.depsChanged) s.fnArgs[s.fnArgs.length - 1] = s.depsChanged;
-  var returnVal = s.fn.apply(s.fn, s.fnArgs);
-  if (returnVal !== undefined) {
-    s(returnVal);
-  }
+  updateCombineStream(s);
   inStream = undefined;
   if (s.depsChanged !== undefined) s.depsChanged = [];
   s.shouldUpdate = false;

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "test": "eslint lib/ test/ module/ && mocha -R dot test/*.js module/**/test/*.js",
     "docs": "documentation -f md lib/index.js > API.md",
     "perf": "./perf/run-benchmarks",
-    "post-to-coveralls-io": "istanbul cover _mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
+    "coverage": "istanbul cover _mocha --report lcovonly -- -R spec",
+    "post-to-coveralls-io": "npm run coverage && cat ./coverage/lcov.info | coveralls && rm -rf ./coverage",
     "build": "browserify -s flyd lib/index.js > flyd.js && uglifyjs flyd.js -o flyd.min.js"
   },
   "repository": {

--- a/test/index.js
+++ b/test/index.js
@@ -74,6 +74,18 @@ describe('stream', function() {
     });
     assert.equal(result, 101);
   });
+
+  it('streams created within stream bodies whose dependencies are not met at creation are updated after their dependencies are met', function() {
+    var result;
+    stream(1).map(function() {
+      var n = stream();
+      n.map(function(v) { result = v + 100; });
+      n(1);
+      assert.equal(result, 101);
+    });
+    assert.equal(result, 101);
+  });
+
   it('has pretty string representation', function() {
     var ns = stream(1);
     var ss = stream('hello');

--- a/test/index.js
+++ b/test/index.js
@@ -269,8 +269,8 @@ describe('stream', function() {
       var result = undefined;
       stream(1).map(function() {
         var n = stream();
-        n.end(true);
         n.map(function(v) { result = v + 100; });
+        n.end(true);
         n(1);
         n(2);
         assert.equal(result, undefined);

--- a/test/index.js
+++ b/test/index.js
@@ -65,27 +65,6 @@ describe('stream', function() {
     assert(!flyd.isStream(f));
   });
 
-  it('streams created within stream bodies whose dependencies are met are evaluated instantly rather than pushed on a queue', function() {
-    var result;
-    stream(1).map(function() {
-      var n = flyd.stream(1);
-      n.map(function(v) { result = v + 100; });
-      assert.equal(result, 101);
-    });
-    assert.equal(result, 101);
-  });
-
-  it('streams created within stream bodies whose dependencies are not met at creation are updated after their dependencies are met', function() {
-    var result;
-    stream(1).map(function() {
-      var n = stream();
-      n.map(function(v) { result = v + 100; });
-      n(1);
-      assert.equal(result, 101);
-    });
-    assert.equal(result, 101);
-  });
-
   it('has pretty string representation', function() {
     var ns = stream(1);
     var ss = stream('hello');
@@ -265,6 +244,40 @@ describe('stream', function() {
       ]);
     });
   });
+
+  describe('streams created within dependent stream bodies', function() {
+    it('if dependencies are met it is updated instantly', function() {
+      var result;
+      stream(1).map(function() {
+        var n = flyd.stream(1);
+        n.map(function(v) { result = v + 100; });
+        assert.equal(result, 101);
+      });
+      assert.equal(result, 101);
+    });
+    it('if dependencies are not met at creation it is updated after their dependencies are met', function() {
+      var result;
+      stream(1).map(function() {
+        var n = stream();
+        n.map(function(v) { result = v + 100; });
+        n(1);
+        assert.equal(result, 101);
+      });
+      assert.equal(result, 101);
+    });
+    it('if a streams end stream is called it takes effect immediately', function() {
+      var result = undefined;
+      stream(1).map(function() {
+        var n = stream();
+        n.end(true);
+        n.map(function(v) { result = v + 100; });
+        n(1);
+        n(2);
+        assert.equal(result, undefined);
+      });
+      assert.equal(result, undefined);
+    });
+  })
 
   describe('ending a stream', function() {
     it('works for streams without dependencies', function() {

--- a/test/index.js
+++ b/test/index.js
@@ -64,6 +64,16 @@ describe('stream', function() {
     assert(flyd.isStream(s3));
     assert(!flyd.isStream(f));
   });
+
+  it('streams created within stream bodies whose dependencies are met are evaluated instantly rather than pushed on a queue', function() {
+    var result;
+    stream(1).map(function() {
+      var n = flyd.stream(1);
+      n.map(function(v) { result = v + 100; });
+      assert.equal(result, 101);
+    });
+    assert.equal(result, 101);
+  });
   it('has pretty string representation', function() {
     var ns = stream(1);
     var ss = stream('hello');


### PR DESCRIPTION
#160 gave a description of a problem where streams created in stream bodies whose dependencies are met at creation time are never given a value. This means expectations are broken as soon as you're in a dependent streams callback.

This can get pretty serious if you're using a framework like `mithril` with flyd.

e.g.
`flyd.on(m.redraw, clickStream)`
can break your app in mysterious ways

The goal of this PR is to deliver the same expectations to things happening inside dependent stream bodies as outside of them.

e.g.

```js
stream(1).map(function() {
  var n = flyd.stream(1);
  n.map(function(v) { result = v + 100; });
  assert.equal(result, 101);
});

stream(1).map(function() {
  var n = stream();
  n.map(function(v) { result = v + 100; });
  n(1);
  assert.equal(result, 101);
});

stream(1).map(function() {
  var n = stream();
  n.map(function(v) { result = v + 100; });
  n.end(true);
  n(1);
  n(2);
  assert.equal(result, undefined);
});
```