### PR TITLE
Fixes an issue where a dependent stream is never updated

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -456,9 +456,11 @@ function initialDepsNotMet(stream) {
  */
 function updateStream(s) {
   if ((s.depsMet !== true && initialDepsNotMet(s)) ||
-      (s.end !== undefined && s.end.val === true)) return;
+    (s.end !== undefined && s.end.val === true)) return;
   if (inStream !== undefined) {
-    toUpdate.push(s);
+    toUpdate.push(function() {
+      updateStream(s);
+    });
     return;
   }
   inStream = s;
@@ -522,9 +524,8 @@ function findDeps(s) {
 function flushUpdate() {
   flushing = true;
   while (toUpdate.length > 0) {
-    var s = toUpdate.shift();
-    if (s.vals.length > 0) s.val = s.vals.shift();
-    updateDeps(s);
+    var updater = toUpdate.shift();
+    updater();
   }
   flushing = false;
 }
@@ -549,8 +550,9 @@ function updateStreamValue(s, n) {
   } else if (inStream === s) {
     markListeners(s, s.listeners);
   } else {
-    s.vals.push(n);
-    toUpdate.push(s);
+    toUpdate.push(function() {
+      updateStreamValue(s, n);
+    });
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -244,6 +244,37 @@ describe('stream', function() {
     });
   });
 
+  describe('streams created within dependent stream bodies', function() {
+    it('if dependencies are met it is updated eventually', function() {
+      var result;
+      stream(1).map(function() {
+        var n = flyd.stream(1);
+        n.map(function(v) { result = v + 100; });
+      });
+      assert.equal(result, 101);
+    });
+    it('if dependencies are not met at creation it is updated after their dependencies are met', function() {
+      var result;
+      stream(1).map(function() {
+        var n = stream();
+        n.map(function(v) { result = v + 100; });
+        n(1);
+      });
+      assert.equal(result, 101);
+    });
+    it('if a streams end stream is called it takes effect immediately', function() {
+      var result = undefined;
+      stream(1).map(function() {
+        var n = stream();
+        n.map(function(v) { result = v + 100; });
+        n.end(true);
+        n(1);
+        n(2);
+      });
+      assert.equal(result, undefined);
+    });
+  })
+
   describe('ending a stream', function() {
     it('works for streams without dependencies', function() {
       var s = stream(1);


### PR DESCRIPTION
as mentioned in #162 

The problem is that when dependent streams are created in the context of other streams `updateStream` pushes the streams to `toUpdate` if their dependencies are met.

`flushUpdate` then updates the dependencies of that stream.

The problem is `flushUpdate` only works for streams updated with `updateStreamValue`. The dependent streams function is never called in `flushUpdate`.

This would need to happen inside flushUpdate for those streams.
```js
if (s.depsChanged) s.fnArgs[s.fnArgs.length - 1] = s.depsChanged;
var returnVal = s.fn.apply(s.fn, s.fnArgs);
if (returnVal !== undefined) {
  s(returnVal);
}
```

I think the solution lies in changing toUpdate from `List Stream` to `List Function`
`flushUpdate` then calls each function in the array in sequence

updateStream would then in stead of calling `toUpdate.push(s)`
```js
toUpdate.push(()=> updateStream(s));
```
and updateStreamValue would do
```js
toUpdate.push(()=> updateStreamValue(s, n));
```

This will result in 
```js
stream(1).map(function() {
  var n = flyd.stream(1);
  n.map(function(v) { result = v + 100; });
  result // undefined
});
result // 101
```

Meaning the mapped stream is guaranteed to run, but maybe not when you expect it to. Which should be fine since you shouldn't really be interacting with dependent streams synchronously.