### PR TITLE
Fix filter type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -192,8 +192,8 @@ declare module 'flyd/module/obj' {
 }
 
 declare module 'flyd/module/previous' {
-  type previous<T> = (stream: flyd.Stream<T>) => flyd.Stream<T>;
-  const _previous: previous;;
+  type previous = <T>(stream: flyd.Stream<T>) => flyd.Stream<T>;
+  const _previous: previous;
   export = _previous;
 }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -121,10 +121,10 @@ declare module 'flyd/module/every' {
 
 declare module 'flyd/module/filter' {
   interface Filter {
-    <T>(predicate: (val: T) => boolean, stream: flyd.Stream<T>): flyd.Stream<T>;
-    <T>(predicate: (val: T) => boolean): (stream: flyd.Stream<T>) => flyd.Stream<T>;
     <T, V extends T>(project: (val: T) => val is V, stream: flyd.Stream<T>): flyd.Stream<V>;
     <T, V extends T>(project: (val: T) => val is V): (stream: flyd.Stream<T>) => flyd.Stream<V>;
+    <T>(predicate: (val: T) => boolean, stream: flyd.Stream<T>): flyd.Stream<T>;
+    <T>(predicate: (val: T) => boolean): (stream: flyd.Stream<T>) => flyd.Stream<T>;
   }
   const _Filter: Filter;
   export = _Filter;


### PR DESCRIPTION
Typescript user type guards only work if they're the first overload of a
method.

This was discussed in PR #173

A test case for this can be found here:

https://www.typescriptlang.org/play/#src=interface%20Stream%3CT%3E%20%7B%0D%0A%20%20readonly%20val%3A%20T%3B%0D%0A%7D%0D%0A%0D%0Ainterface%20Filter%20%7B%0D%0A%20%20%3CT%3E(predicate%3A%20(value%3A%20T)%20%3D%3E%20boolean%2C%20stream%3A%20Stream%3CT%3E)%3A%20Stream%3CT%3E%3B%0D%0A%20%20%3CT%2C%20V%20extends%20T%3E(predicate%3A%20(value%3A%20T)%20%3D%3E%20value%20is%20V%2C%20stream%3A%20Stream%3CT%3E)%3A%20Stream%3CV%3E%3B%0D%0A%7D%0D%0A%0D%0Ainterface%20Filter2%20%7B%0D%0A%20%20%3CT%2C%20V%20extends%20T%3E(predicate%3A%20(value%3A%20T)%20%3D%3E%20value%20is%20V%2C%20stream%3A%20Stream%3CT%3E)%3A%20Stream%3CV%3E%3B%0D%0A%20%20%3CT%3E(predicate%3A%20(value%3A%20T)%20%3D%3E%20boolean%2C%20stream%3A%20Stream%3CT%3E)%3A%20Stream%3CT%3E%3B%20%20%0D%0A%7D%0D%0A%0D%0Aconst%20filter%20%3D%20(window.asdf%20as%20any%20as%20Filter)%3B%0D%0Aconst%20filter2%20%3D%20(window.asdff%20as%20any%20as%20Filter2)%3B%0D%0A%0D%0Aconst%20stream%20%3D%20%3CT%3E(val%3A%20T)%3A%20Stream%3CT%3E%20%3D%3E%20(%7B%20val%20%7D)%3B%0D%0A%0D%0Aconst%20isString%20%3D%20(val%3A%20any)%20%3A%20val%20is%20string%20%3D%3E%20typeof%20val%20%3D%3D%3D%20'string'%0D%0A%0D%0Aconst%20a%20%3D%20filter(val%20%3D%3E%20val%20!%3D%3D%200%2C%20stream(0))%3B%0D%0A%0D%0Aconst%20b%20%3D%20stream%3Cnumber%20%7C%20string%3E(0)%3B%0D%0A%0D%0Aconst%20c%20%3D%20filter(isString%2C%20b)%3B%0D%0Aconst%20d%20%3D%20filter2(isString%2C%20b)%3B