### PR TITLE
Fix #177 multilevel dependent streams inside other stream bodies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -594,7 +594,14 @@ function initialDepsNotMet(stream) {
  */
 function updateStream(s) {
   if ((s.depsMet !== true && initialDepsNotMet(s)) ||
-    (s.end !== undefined && s.end.val === true)) return;
+    (s.end !== undefined && s.end.val === true)) {
+    if (toUpdate.length > 0 && inStream !== undefined) {
+      toUpdate.push(function() {
+        updateStream(s);
+      });
+    }
+    return;
+  }
   if (inStream !== undefined) {
     toUpdate.push(function() {
       updateStream(s);

--- a/test/index.js
+++ b/test/index.js
@@ -276,7 +276,24 @@ describe('stream', function() {
       }));
       assert.equal(result, undefined);
     });
-  })
+    it('can create multi-level dependent streams inside a stream body', function() {
+      var result = 0;
+      var externalStream = stream(0);
+      stream(1).map(function() {
+        externalStream
+          .map(function() {
+            result += 1;
+            return 0;
+          })
+          .map(function() {
+            result += 2;
+            return 0;
+          });
+        return;
+      });
+      assert.equal(result, 3);
+    });
+  });
 
   describe('ending a stream', function() {
     it('works for streams without dependencies', function() {


### PR DESCRIPTION
When the dep streams don't have a value, check if `inStream` has a value and if `toUpdate` has received some calls already, if yes, assume that our dep streams are just queued to be updated during flush and do the same for the current one.