### PR TITLE
Fixes #179

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
-  - "0.12"
-  - "0.10"
-  - "iojs"
-  - "4"
-  - "5"
+  - "6"
+  - "7"
+  - "8"
 after_success:
   - "npm run post-to-coveralls-io"

--- a/lib/index.js
+++ b/lib/index.js
@@ -535,7 +535,7 @@ function createStream() {
   }
   s.hasVal = false;
   s.val = undefined;
-  s.vals = [];
+  s.updaters = [];
   s.listeners = [];
   s.queued = false;
   s.end = undefined;
@@ -610,9 +610,7 @@ function updateStream(s) {
   if (isEnded(s)) return;
   if (s.depsMet !== true && initialDepsNotMet(s)) return;
   if (inStream !== undefined) {
-    toUpdate.push(function() {
-      updateStream(s);
-    });
+    updateLaterUsing(updateStream, s);
     return;
   }
   inStream = s;
@@ -673,14 +671,21 @@ function findDeps(s) {
   }
 }
 
+function updateLaterUsing(updater, stream) {
+  toUpdate.push(stream);
+  stream.updaters.push(updater);
+  stream.shouldUpdate = true;
+}
+
 /**
  * @private
  */
 function flushUpdate() {
   flushingUpdateQueue = true;
   while (toUpdate.length > 0) {
-    var updater = toUpdate.shift();
-    updater();
+    var stream = toUpdate.shift();
+    var nextUpdateFn = stream.updaters.shift();
+    if (nextUpdateFn && stream.shouldUpdate) nextUpdateFn(stream);
   }
   flushingUpdateQueue = false;
 }
@@ -701,9 +706,7 @@ function updateStreamValue(n, s) {
   } else if (inStream === s) {
     markListeners(s, s.listeners);
   } else {
-    toUpdate.push(function() {
-      updateStreamValue(n, s);
-    });
+    updateLaterUsing(function(s) { updateStreamValue(n, s); }, s);
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -587,11 +587,15 @@ function createDependentStream(deps, fn) {
  * @param {stream} stream - the stream to check depencencies from
  * @return {Boolean} `true` if all dependencies have vales, `false` otherwise
  */
-function initialDepsNotMet(stream) {
+function initialDependenciesMet(stream) {
   stream.depsMet = stream.deps.every(function(s) {
     return s.hasVal;
   });
-  return !stream.depsMet;
+  return stream.depsMet;
+}
+
+function dependenciesAreMet(stream) {
+  return stream.depsMet === true || initialDependenciesMet(stream);
 }
 
 function isEnded(stream) {
@@ -599,7 +603,7 @@ function isEnded(stream) {
 }
 
 function listenersNeedUpdating(s) {
-  return !flushingStreamValue && s.listeners.some(function(s) { return s.shouldUpdate; });
+  return s.listeners.some(function(s) { return s.shouldUpdate; });
 }
 
 /**
@@ -608,8 +612,7 @@ function listenersNeedUpdating(s) {
  * @param {stream} stream - the stream to update
  */
 function updateStream(s) {
-  if (isEnded(s)) return;
-  if (s.depsMet !== true && initialDepsNotMet(s)) return;
+  if (isEnded(s) || !dependenciesAreMet(s)) return;
   if (inStream !== undefined) {
     updateLaterUsing(updateStream, s);
     return;
@@ -625,7 +628,12 @@ function updateStream(s) {
   s.shouldUpdate = false;
   if (flushing() === false) flushUpdate();
   if (listenersNeedUpdating(s)) {
-    s(s.val);
+    if (!flushingStreamValue) s(s.val)
+    else {
+      s.listeners.forEach(function(listener) {
+        if (listener.shouldUpdate) updateLaterUsing(updateStream, listener);
+      });
+    }
   }
 }
 
@@ -703,7 +711,8 @@ function updateStreamValue(n, s) {
   if (inStream === undefined) {
     flushingStreamValue = true;
     updateListeners(s);
-    if (toUpdate.length > 0) flushUpdate(); else flushingStreamValue = false;
+    if (toUpdate.length > 0) flushUpdate();
+    flushingStreamValue = false;
   } else if (inStream === s) {
     markListeners(s, s.listeners);
   } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,7 +13,13 @@ var toUpdate = [];
 var inStream;
 var order = [];
 var orderNextIdx = -1;
-var flushing = false;
+var flushingUpdateQueue = false;
+var flushingStreamValue = false;
+
+function flushing() {
+  return flushingUpdateQueue || flushingStreamValue;
+}
+
 
 /** @namespace */
 var flyd = {}
@@ -524,7 +530,7 @@ function streamToString() {
 function createStream() {
   function s(n) {
     if (arguments.length === 0) return s.val
-    updateStreamValue(s, n)
+    updateStreamValue(n, s)
     return s
   }
   s.hasVal = false;
@@ -587,21 +593,22 @@ function initialDepsNotMet(stream) {
   return !stream.depsMet;
 }
 
+function isEnded(stream) {
+  return stream.end && stream.end.val === true;
+}
+
+function listenersNeedUpdating(s) {
+  return !flushingStreamValue && s.listeners.some(function(s) { return s.shouldUpdate; });
+}
+
 /**
  * @private
  * Update a dependent stream using its dependencies in an atomic way
  * @param {stream} stream - the stream to update
  */
 function updateStream(s) {
-  if ((s.depsMet !== true && initialDepsNotMet(s)) ||
-    (s.end !== undefined && s.end.val === true)) {
-    if (toUpdate.length > 0 && inStream !== undefined) {
-      toUpdate.push(function() {
-        updateStream(s);
-      });
-    }
-    return;
-  }
+  if (isEnded(s)) return;
+  if (s.depsMet !== true && initialDepsNotMet(s)) return;
   if (inStream !== undefined) {
     toUpdate.push(function() {
       updateStream(s);
@@ -617,7 +624,10 @@ function updateStream(s) {
   inStream = undefined;
   if (s.depsChanged !== undefined) s.depsChanged = [];
   s.shouldUpdate = false;
-  if (flushing === false) flushUpdate();
+  if (flushing() === false) flushUpdate();
+  if (listenersNeedUpdating(s)) {
+    s(s.val);
+  }
 }
 
 /**
@@ -625,7 +635,7 @@ function updateStream(s) {
  * Update the dependencies of a stream
  * @param {stream} stream
  */
-function updateDeps(s) {
+function updateListeners(s) {
   var i, o, list
   var listeners = s.listeners;
   for (i = 0; i < listeners.length; ++i) {
@@ -667,12 +677,12 @@ function findDeps(s) {
  * @private
  */
 function flushUpdate() {
-  flushing = true;
+  flushingUpdateQueue = true;
   while (toUpdate.length > 0) {
     var updater = toUpdate.shift();
     updater();
   }
-  flushing = false;
+  flushingUpdateQueue = false;
 }
 
 /**
@@ -681,18 +691,18 @@ function flushUpdate() {
  * @param {stream} stream
  * @param {*} value
  */
-function updateStreamValue(s, n) {
+function updateStreamValue(n, s) {
   s.val = n;
   s.hasVal = true;
   if (inStream === undefined) {
-    flushing = true;
-    updateDeps(s);
-    if (toUpdate.length > 0) flushUpdate(); else flushing = false;
+    flushingStreamValue = true;
+    updateListeners(s);
+    if (toUpdate.length > 0) flushUpdate(); else flushingStreamValue = false;
   } else if (inStream === s) {
     markListeners(s, s.listeners);
   } else {
     toUpdate.push(function() {
-      updateStreamValue(s, n);
+      updateStreamValue(n, s);
     });
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -186,9 +186,10 @@ flyd.endsOn = function(endS, s) {
  * var squaredNumbers = flyd.map(function(n) { return n*n; }, numbers);
  */
 // Library functions use self callback to accept (null, undefined) update triggers.
-flyd.map = curryN(2, function(f, s) {
+function map(f, s) {
   return combine(function(s, self) { self(f(s.val)); }, [s]);
-})
+}
+flyd.map = curryN(2, map)
 
 /**
  * Chain a stream
@@ -385,7 +386,7 @@ flyd.curryN = curryN
  * var numbers = flyd.stream(0);
  * var squaredNumbers = numbers.map(function(n) { return n*n; });
  */
-function boundMap(f) { return flyd.map(f, this); }
+function boundMap(f) { return map(f, this); }
 
 /**
  * Returns the result of applying function `fn` to this stream
@@ -427,7 +428,7 @@ function chain(f, s) {
     internalEnded(newS.end);
 
     // Update self on call -- newS is never handed out so deps don't matter
-    last = flyd.map(own, newS);
+    last = map(own, newS);
   }, [s]);
 
   flyd.endsOn(flatEnd.end, flatStream);

--- a/module/switchlatest/index.js
+++ b/module/switchlatest/index.js
@@ -1,11 +1,12 @@
 var flyd = require('../../lib');
+var takeUntil = require('../takeuntil');
+var drop = require('ramda/src/drop');
+
+var dropCurrentValue = flyd.transduce(drop(1));
 
 module.exports = function(s) {
-  var inner;
-  return flyd.combine(function(s, self) {
-    inner = s();
-    flyd.endsOn(flyd.merge(s, inner.end), flyd.combine(function(inner) {
-      self(inner());
-    }, [inner]));
+  return flyd.combine(function(stream$, self) {
+    var value$ = stream$();
+    flyd.on(self, takeUntil(value$, dropCurrentValue(stream$)));
   }, [s]);
 };

--- a/module/switchlatest/test/index.js
+++ b/module/switchlatest/test/index.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 
 var switchLatest = require('../index.js');
 
-describe('takeUntil', function() {
+describe('switchLatest', function() {
   it('emits values from first stream in stream', function() {
     var result = [];
     var source = stream();

--- a/module/takeuntil/test/index.js
+++ b/module/takeuntil/test/index.js
@@ -11,7 +11,7 @@ describe('takeUntil', function() {
     var terminator = stream();
     var s = takeUntil(source, terminator);
     flyd.map(function(v) { result.push(v); }, s);
-    s(1)(2)(3);
+    source(1)(2)(3);
     assert.deepEqual(result, [1, 2, 3]);
   });
   it('ends when value emitted from second stream', function() {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "scripts": {
     "test-lib": "mocha",
-    "test": "eslint --fix lib/ test/ module/ && mocha -R dot test/*.js module/**/test/*.js",
+    "test": "eslint --fix lib/ test/ module/ && mocha test/*.js module/**/test/*.js",
     "docs": "documentation -f md lib/index.js > API.md",
     "perf": "./perf/run-benchmarks",
     "coverage": "istanbul cover _mocha -- -R spec",

--- a/test/index.js
+++ b/test/index.js
@@ -279,19 +279,17 @@ describe('stream', function() {
     it('can create multi-level dependent streams inside a stream body', function() {
       var result = 0;
       var externalStream = stream(0);
+      function mapper(val) {
+        ++result;
+        return val + 1;
+      }
       stream(1).map(function() {
         externalStream
-          .map(function() {
-            result += 1;
-            return 0;
-          })
-          .map(function() {
-            result += 2;
-            return 0;
-          });
+          .map(mapper)
+          .map(mapper);
         return;
       });
-      assert.equal(result, 3);
+      assert.equal(result, 2);
     });
   });
 
@@ -1005,6 +1003,19 @@ describe('stream', function() {
       assert.deepEqual(result, [
         [], [1, 3, 2], [2, 8, 7, 6], [3, 5, 4]
       ]);
+    });
+    it('#179 nested streams atomic update', function() {
+      var invocationCount = 0;
+      var mapper = function(val) {
+        invocationCount += 1;
+        return val + 1;
+      };
+      stream(1).map(function() {
+        stream(0)
+        .map(mapper)
+        .map(mapper);
+      });
+      assert.equal(invocationCount, 2);
     });
   });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1004,7 +1004,7 @@ describe('stream', function() {
         [], [1, 3, 2], [2, 8, 7, 6], [3, 5, 4]
       ]);
     });
-    it('#179 nested streams atomic update', function() {
+    it('nested streams atomic update', function() {
       var invocationCount = 0;
       var mapper = function(val) {
         invocationCount += 1;

--- a/test/index.js
+++ b/test/index.js
@@ -291,6 +291,23 @@ describe('stream', function() {
       });
       assert.equal(result, 2);
     });
+    it('can create multi-level dependent streams inside a stream body part 2', function() {
+      var result = '';
+      var externalStream = stream(0);
+      var theStream = stream(1);
+      function mapper(val) {
+        result += '' + val;
+        return val + 1;
+      }
+      theStream.map(function() {
+        externalStream
+          .map(mapper)
+          .map(mapper);
+        return;
+      });
+      theStream(1);
+      assert.equal(result, '0101');
+    });
   });
 
   describe('ending a stream', function() {


### PR DESCRIPTION
We were tracking flushing using one variable while there
were in fact two types of flushing `flushingStreamValue`, and `flushingUpdateQueue`. This is now properly represented as two distinct case.

At the end of the updateStream method I've added a check, that if we're not flushingStreamValue and the streams listeners should be updated then we call `s(s.val)` to force that update.

Finally the update queue has been changed a bit. It now holds streams again. But the streams hold updater function arrays.

Hope you have time to review this soon @paldepind